### PR TITLE
Add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,20 @@
+{
+  "name": "mixpanel-js",
+  "version": "2.3.2",
+  "homepage": "https://github.com/mixpanel/mixpanel-js",
+  "description": "Mixpanel JavaScript Library",
+  "main": "mixpanel-jslib-snippet.js",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:mixpanel/mixpanel-js.git"
+  },
+  "keywords": [
+    "mixpanel",
+    "mixpaneljs",
+    "mixpanel-js"
+  ],
+  "license": "Apache-2.0",
+  "ignore": [
+    "tests"
+  ]
+}

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "mixpanel-js",
-  "version": "2.3.2",
   "homepage": "https://github.com/mixpanel/mixpanel-js",
   "description": "Mixpanel JavaScript Library",
   "main": "mixpanel-jslib-snippet.js",

--- a/build.sh
+++ b/build.sh
@@ -9,5 +9,5 @@ java -jar $1 --js mixpanel.js --js_output_file mixpanel.min.js --compilation_lev
 %output%
 })();"
 
-java -jar $1 --js mixpanel-jslib-snippet.js --js_output_file mixpanel-jslib-snippet.min.js --compilation_level ADVANCED_OPTIMIZATIONS --define='LIB_URL="//cdn.mxpnl.com/libs/mixpanel-2.2.js"'
+java -jar $1 --js mixpanel-jslib-snippet.js --js_output_file mixpanel-jslib-snippet.min.js --compilation_level ADVANCED_OPTIMIZATIONS --define='MIXPANEL_LIB_URL="//cdn.mxpnl.com/libs/mixpanel-2.2.js"'
 

--- a/build.sh
+++ b/build.sh
@@ -9,5 +9,5 @@ java -jar $1 --js mixpanel.js --js_output_file mixpanel.min.js --compilation_lev
 %output%
 })();"
 
-java -jar $1 --js mixpanel-jslib-snippet.js --js_output_file mixpanel-jslib-snippet.min.js --compilation_level ADVANCED_OPTIMIZATIONS --define='MIXPANEL_LIB_URL="//cdn.mxpnl.com/libs/mixpanel-2.2.js"'
+java -jar $1 --js mixpanel-jslib-snippet.js --js_output_file mixpanel-jslib-snippet.min.js --compilation_level ADVANCED_OPTIMIZATIONS
 

--- a/mixpanel-jslib-snippet.js
+++ b/mixpanel-jslib-snippet.js
@@ -4,7 +4,7 @@
 // ==/ClosureCompiler==
 
 /** @define {string} */
-var LIB_URL = '../mixpanel.js';
+var MIXPANEL_LIB_URL = '//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js';
 
 (function(document, mixpanel){
     // Only stub out if this is the first time running the snippet.
@@ -69,8 +69,7 @@ var LIB_URL = '../mixpanel.js';
         script.type = "text/javascript";
         script.async = true;
 
-        // The default url is intended to be relative to the tests/tests.html file
-        script.src = LIB_URL;
+        script.src = MIXPANEL_LIB_URL;
 
         first_script = document.getElementsByTagName("script")[0];
         first_script.parentNode.insertBefore(script, first_script);


### PR DESCRIPTION
Add ability to include mixpanel-js from this repository instead of using https://mixpanel.com/help/reference/javascript snippet.