### PR TITLE
add $browser_version super property

### DIFF
--- a/mixpanel.js
+++ b/mixpanel.js
@@ -1326,6 +1326,32 @@ Globals should be all caps
             }
         },
 
+        /**
+         * This function detects which browser version (eg. "Chrome 42") is
+         * running this script.
+         */
+        browserVersion: function(userAgent, vendor, opera) {
+            var browser = _.info.browser(userAgent, vendor, opera);
+            var versionRegexs = {
+                "Chrome":            /Chrome\/([\d]+)/,
+                "Chrome iOS":        /Chrome\/([\d]+)/,
+                "Safari":            /Safari\/([\d]+)/,
+                "Mobile Safari":     /Safari\/([\d]+)/,
+                "Opera":             /Opera\/([\d]+)/,
+                "Firefox":           /Firefox\/([\d]+)/,
+                "Konqueror":         /Konqueror:([\d]+)/,
+                "BlackBerry":        /BlackBerry ([\d]+)/,
+                "Android Mobile":    /android\s([\d]+)/,
+                "Internet Explorer": /(rv:|MSIE )([^)]+)/,
+                "Mozilla":           /rv:([^)]+)/
+            };
+            var regex = versionRegexs[browser];
+            if (regex == undefined) return "";
+            var matches = userAgent.match(regex);
+            if(!matches) return "";
+            return browser + " " + matches[matches.length - 1];
+        },
+
         os: function() {
             var a = userAgent;
             if (/Windows/i.test(a)) {
@@ -1376,6 +1402,7 @@ Globals should be all caps
             return _.extend(_.strip_empty_properties({
                 '$os': _.info.os(),
                 '$browser': _.info.browser(userAgent, navigator.vendor, window.opera),
+                '$browser_version': _.info.browserVersion(userAgent, navigator.vendor, window.opera),
                 '$referrer': document.referrer,
                 '$referring_domain': _.info.referringDomain(document.referrer),
                 '$device': _.info.device(userAgent)
@@ -1390,7 +1417,8 @@ Globals should be all caps
         people_properties: function() {
             return _.strip_empty_properties({
                 '$os': _.info.os(),
-                '$browser': _.info.browser(userAgent, navigator.vendor, window.opera)
+                '$browser': _.info.browser(userAgent, navigator.vendor, window.opera),
+                '$browser_version': _.info.browserVersion(userAgent, navigator.vendor, window.opera)
             });
         },
 

--- a/mixpanel.js
+++ b/mixpanel.js
@@ -1346,10 +1346,10 @@ Globals should be all caps
                 "Mozilla":           /rv:([^)]+)/
             };
             var regex = versionRegexs[browser];
-            if (regex == undefined) return "";
+            if (regex == undefined) return undefined;
             var matches = userAgent.match(regex);
-            if(!matches) return "";
-            return browser + " " + matches[matches.length - 1];
+            if(!matches) return undefined;
+            return parseFloat(matches[matches.length - 1]);
         },
 
         os: function() {
@@ -1402,11 +1402,11 @@ Globals should be all caps
             return _.extend(_.strip_empty_properties({
                 '$os': _.info.os(),
                 '$browser': _.info.browser(userAgent, navigator.vendor, window.opera),
-                '$browser_version': _.info.browserVersion(userAgent, navigator.vendor, window.opera),
                 '$referrer': document.referrer,
                 '$referring_domain': _.info.referringDomain(document.referrer),
                 '$device': _.info.device(userAgent)
             }), {
+                '$browser_version': _.info.browserVersion(userAgent, navigator.vendor, window.opera),
                 '$screen_height': screen.height,
                 '$screen_width': screen.width,
                 'mp_lib': 'web',
@@ -1415,9 +1415,10 @@ Globals should be all caps
         },
 
         people_properties: function() {
-            return _.strip_empty_properties({
+            return _.extend(_.strip_empty_properties({
                 '$os': _.info.os(),
-                '$browser': _.info.browser(userAgent, navigator.vendor, window.opera),
+                '$browser': _.info.browser(userAgent, navigator.vendor, window.opera)
+            }), {
                 '$browser_version': _.info.browserVersion(userAgent, navigator.vendor, window.opera)
             });
         },

--- a/tests/test.js
+++ b/tests/test.js
@@ -854,8 +854,8 @@ mpmodule("mixpanel");
         clearLibInstance(mixpanel.mpl3);
     });
 
-    test("info properties included", 5, function() {
-        var info_props = "$os $browser $referrer $referring_domain mp_lib".split(' ');
+    test("info properties included", 6, function() {
+        var info_props = "$os $browser $browser_version $referrer $referring_domain mp_lib".split(' ');
 
         var data = mixpanel.test.track("check info props");
         _.each(info_props, function(prop) {
@@ -1375,8 +1375,8 @@ mpmodule("mixpanel.people.set");
         ok(contains_obj(s['$set'], { 'a': 3 }));
     });
 
-    test("set (info props included)", 4, function() {
-        var info_props = "$os $browser $initial_referrer $initial_referring_domain".split(' ');
+    test("set (info props included)", 5, function() {
+        var info_props = "$os $browser $browser_version $initial_referrer $initial_referring_domain".split(' ');
 
         var data = mixpanel.people.set('key1', 'test');
 
@@ -1431,8 +1431,8 @@ mpmodule("mixpanel.people.set_once");
         ok(contains_obj(s['$set_once'], { 'a': 3 }));
     });
 
-    test("set_once (info props not included)", 4, function() {
-        var info_props = "$os $browser $initial_referrer $initial_referring_domain".split(' ');
+    test("set_once (info props not included)", 5, function() {
+        var info_props = "$os $browser $browser_version $initial_referrer $initial_referring_domain".split(' ');
 
         var data = mixpanel.people.set_once('key1', 'test');
 


### PR DESCRIPTION
Adding a $browser_version super property to distinguish individual browser version (eg. Chrome 42 vs. Chrome 40). As discussed in issue #14 this would be useful in determining a site's browser segregation.

I've updated the tests to include the $browser_version property and all tests are passing.

The user agent strings are based on http://www.useragentstring.com/pages/useragentstring.php