### PR TITLE
Adds MS Edge recognition to Browser property

### DIFF
--- a/mixpanel.js
+++ b/mixpanel.js
@@ -1302,6 +1302,8 @@ Globals should be all caps
                 return 'BlackBerry';
             } else if (_.includes(user_agent, "FBIOS")) {
                 return "Facebook Mobile";
+            } else if (_.includes(user_agent, "Edge")) {
+            	return "Microsoft Edge";
             } else if (_.includes(user_agent, "Chrome")) {
                 return "Chrome";
             } else if (_.includes(user_agent, "CriOS")) {
@@ -1344,7 +1346,8 @@ Globals should be all caps
                 "BlackBerry":        /BlackBerry (\d+(\.\d+)?)/,
                 "Android Mobile":    /android\s(\d+(\.\d+)?)/,
                 "Internet Explorer": /(rv:|MSIE )(\d+(\.\d+)?)/,
-                "Mozilla":           /rv:(\d+(\.\d+)?)/
+                "Mozilla":           /rv:(\d+(\.\d+)?)/,
+                "Edge":              /Edge\/(\d+(\.\d+)?)/
             };
             var regex = versionRegexs[browser];
             if (regex == undefined) {


### PR DESCRIPTION
based on guidance from https://msdn.microsoft.com/en-us/library/hh869301(v=vs.85).aspx

Being Windows there isn't a userAgent change to the "Edge" string on mobile, but it is certainly possible to create a "Mobile Edge" designation based on other elements in the userAgent.