### PR TITLE
Add support for new Opera browser versions

### DIFF
--- a/mixpanel.js
+++ b/mixpanel.js
@@ -1338,7 +1338,7 @@ Globals should be all caps
                 "Chrome iOS":        /Chrome\/(\d+(\.\d+)?)/,
                 "Safari":            /Version\/(\d+(\.\d+)?)/,
                 "Mobile Safari":     /Version\/(\d+(\.\d+)?)/,
-                "Opera":             /Opera\/(\d+(\.\d+)?)/,
+                "Opera":             /(Opera|OPR)\/(\d+(\.\d+)?)/,
                 "Firefox":           /Firefox\/(\d+(\.\d+)?)/,
                 "Konqueror":         /Konqueror:(\d+(\.\d+)?)/,
                 "BlackBerry":        /BlackBerry (\d+(\.\d+)?)/,

--- a/mixpanel.js
+++ b/mixpanel.js
@@ -1293,7 +1293,7 @@ Globals should be all caps
          */
         browser: function(user_agent, vendor, opera) {
             var vendor = vendor || ''; // vendor is undefined for at least IE9
-            if (opera) {
+            if (opera || /(OPR)/i.test(navigator.userAgent)) {
                 if (_.includes(user_agent, "Mini")) {
                     return "Opera Mini";
                 }


### PR DESCRIPTION
New Opera versions (appears to have changed in version 30) are no longer captured by our current browser picking hierarchy. This PR is intended to add support for the new format and keep support for legacy versions by looking for an additional check on the user agent.

Here is an example new user agent (this looks for the string 'OPR'): "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36 OPR/30.0.1835.125"
