### PR TITLE
better matching for Windows Phone devices

### DIFF
--- a/mixpanel.js
+++ b/mixpanel.js
@@ -1386,12 +1386,12 @@ Globals should be all caps
         },
 
         device: function(user_agent) {
-            if (/iPad/.test(user_agent)) {
+            if (/Windows Phone/i.test(user_agent) || /WPDesktop/.test(user_agent)) {
+                return 'Windows Phone';
+            } else if (/iPad/.test(user_agent)) {
                 return 'iPad';
             } else if (/iPod/.test(user_agent)) {
                 return 'iPod Touch';
-            } else if (/Windows Phone/i.test(user_agent) || /WPDesktop/.test(user_agent)) {
-                return 'Windows Phone';
             } else if (/iPhone/.test(user_agent)) {
                 return 'iPhone';
             } else if (/(BlackBerry|PlayBook|BB10)/i.test(user_agent)) {


### PR DESCRIPTION
while $os always matches if Windows Phone, $device had "ipad" as the primary if match - as WP useragents seem to always carry ipad/ipod-like at this point (Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 930) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537) I moved the WP regex block up

@tdumitrescu - thoughts? 