### PR TITLE
Adding support for Firefox browser on iOS 

### DIFF
--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -1312,6 +1312,8 @@ _.info = {
             return "Chrome";
         } else if (_.includes(user_agent, "CriOS")) {
             return "Chrome iOS";
+        } else if (_.includes(user_agent, "FxiOS")) {
+            return "Firefox iOS";
         } else if (_.includes(vendor, "Apple")) {
             if (_.includes(user_agent, "Mobile")) {
                 return "Mobile Safari";
@@ -1348,6 +1350,7 @@ _.info = {
             "Mobile Safari":            /Version\/(\d+(\.\d+)?)/,
             "Opera":                    /(Opera|OPR)\/(\d+(\.\d+)?)/,
             "Firefox":                  /Firefox\/(\d+(\.\d+)?)/,
+            "Firefox iOS":              /FxiOS\/(\d+(\.\d+)?)/,
             "Konqueror":                /Konqueror:(\d+(\.\d+)?)/,
             "BlackBerry":               /BlackBerry (\d+(\.\d+)?)/,
             "Android Mobile":           /android\s(\d+(\.\d+)?)/,


### PR DESCRIPTION
Recently, Firefox changed the user agent for their mobile browser to the below:

Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) FxiOS/1.3 Mobile/13B143 Safari/601.1.46

Due to this change, our library is mistakenly categorizing this as Mobile Safari. This change will pick up the correct pattern for the user agent and assign the browser property correctly.