### PR TITLE
Adding reset method to handle generating a new distinct_id and clearing persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you originally installed Mixpanel via Bower at its previous home ([https://gi
 
 ## Running tests
 - Install development dependencies: `npm install`
-- Start test server: `npm start`
+- Start test server: `npm test`
 - Browse to [http://localhost:3000/tests/](http://localhost:3000/tests/) and choose a scenario to run
 
 In the future we plan to automate the last step with a headless browser to streamline development (although

--- a/mixpanel-jslib-snippet.js
+++ b/mixpanel-jslib-snippet.js
@@ -53,7 +53,7 @@ var MIXPANEL_LIB_URL = '//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js';
 
             // create shallow clone of the public mixpanel interface
             // Note: only supports 1 additional level atm, e.g. mixpanel.people.set, not mixpanel.people.set.do_something_else.
-            functions = "disable time_event track track_pageview track_links track_forms register register_once alias unregister identify name_tag set_config people.set people.set_once people.increment people.append people.union people.track_charge people.clear_charges people.delete_user".split(' ');
+            functions = "disable time_event track track_pageview track_links track_forms register register_once alias unregister identify name_tag set_config reset people.set people.set_once people.increment people.append people.union people.track_charge people.clear_charges people.delete_user".split(' ');
             for (i = 0; i < functions.length; i++) {
                 _set_and_defer(target, functions[i]);
             }

--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -2129,6 +2129,15 @@ MixpanelLib.prototype.init = function (token, config, name) {
     return instance;
 };
 
+/**
+ * This function clears super properties by clearing persistence 
+ * and generates a new distinct_id for the mixpanel instance.
+ */
+MixpanelLib.prototype.reset = function() {
+    this.persistence.clear();
+    this.identify(_.UUID());
+};
+
 // mixpanel._init(token:string, config:object, name:string)
 //
 // This function sets up the current instance of the mixpanel
@@ -4652,6 +4661,7 @@ _['info']['properties'] = _.info.properties;
 
 // MixpanelLib Exports
 MixpanelLib.prototype['init']                            = MixpanelLib.prototype.init;
+MixpanelLib.prototype['reset']                           = MixpanelLib.prototype.reset;
 MixpanelLib.prototype['disable']                         = MixpanelLib.prototype.disable;
 MixpanelLib.prototype['time_event']                      = MixpanelLib.prototype.time_event;
 MixpanelLib.prototype['track']                           = MixpanelLib.prototype.track;

--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -2130,12 +2130,12 @@ MixpanelLib.prototype.init = function (token, config, name) {
 };
 
 /**
- * This function clears super properties by clearing persistence 
+ * This function clears super properties by clearing persistence
  * and generates a new distinct_id for the mixpanel instance.
  */
 MixpanelLib.prototype.reset = function() {
     this.persistence.clear();
-    this.identify(_.UUID());
+    this.register_once({'distinct_id': _.UUID()}, "");
 };
 
 // mixpanel._init(token:string, config:object, name:string)

--- a/tests/test.js
+++ b/tests/test.js
@@ -2166,6 +2166,29 @@ mpmodule('user agent parser');
             ok(mixpanel._.isBlockedUA(ua));
         });
     });
+    
+mpmodule("mixpanel.reset");
+
+    test('reset generates new distinct_id', 1, function() {
+        var id = '1234',
+            instance = mixpanel.init('token');            
+        
+        mixpanel.identify(id);    
+        mixpanel.reset();
+        
+        notEqual(id, mixpanel.get_distinct_id());
+    });
+    
+    test('reset clears super properties', 1, function() {
+        var instance = mixpanel.init('token'),
+            properties = { foo: 1 };
+        
+        mixpanel.register(properties);
+        mixpanel.reset();
+        
+        var propertiesAfterReset = mixpanel.persistence.properties();
+        notEqual(properties.foo, propertiesAfterReset.foo);
+    });
 
 if( /Android|iPhone|iPad|iPod|BlackBerry|Windows Phone/i.test(navigator.userAgent) ) {
     mpmodule("mobile tests");


### PR DESCRIPTION
I saw this talked about over in issue #67 and there was a solution given, seems to me as it should be a part of the library as it is a common operation we require.

This PR should address that, if I have missed anything I am happy to fix it up but it appears to be working to me.