### PR TITLE
don't add stripped value properties to elements

### DIFF
--- a/src/ce.js
+++ b/src/ce.js
@@ -40,8 +40,9 @@ var ce = {
             'tag_name': elem.tagName
         };
 
-        if (_.includes(['input', 'select', 'textarea'], elem.tagName.toLowerCase())) {
-            props['value'] = this._getFormFieldValue(elem);
+        var form_field_value = this._getFormFieldValue(elem);
+        if (_.includes(['input', 'select', 'textarea'], elem.tagName.toLowerCase()) && form_field_value !== '[stripped]') {
+            props[ 'value'] = form_field_value;
         }
 
         _.each(elem.attributes, function(attr) {
@@ -198,7 +199,7 @@ var ce = {
             if (name !== null) {
                 name = '$form_field__' + name;
                 var val = this._getFormFieldValue(field);
-                if (val !== undefined) {
+                if (val !== undefined && val !== '[stripped]') {
                     var prevFieldVal = formFieldProps[name];
                     if (prevFieldVal !== undefined) { // combine values for inputs of same name
                         formFieldProps[name] = [].concat(prevFieldVal, val);

--- a/src/ce.js
+++ b/src/ce.js
@@ -40,9 +40,9 @@ var ce = {
             'tag_name': elem.tagName
         };
 
-        var form_field_value = this._getFormFieldValue(elem);
-        if (_.includes(['input', 'select', 'textarea'], elem.tagName.toLowerCase()) && this._includeProperty(elem, value)) {
-            props[ 'value'] = form_field_value;
+        var formFieldValue = this._getFormFieldValue(elem);
+        if (_.includes(['input', 'select', 'textarea'], elem.tagName.toLowerCase()) && this._includeProperty(elem, formFieldValue)) {
+            props['value'] = formFieldValue;
         }
 
         _.each(elem.attributes, function(attr) {
@@ -135,7 +135,7 @@ var ce = {
 
     _includeProperty: function(input, value) {
         var classes = (input.className || '').split(' ');
-        if (_.includes(classes, 'mp-always-include-value')) { // never sanitize inputs with class "mp-never-strip-value"
+        if (_.includes(classes, 'mp-always-include-value')) {
             return true;
         }
 
@@ -170,7 +170,6 @@ var ce = {
             }
         }
 
-        // return unmodified value
         return true;
     },
 
@@ -197,7 +196,7 @@ var ce = {
             if (name !== null) {
                 name = '$form_field__' + name;
                 var val = this._getFormFieldValue(field);
-                if (this._includeProperty(field, value) && val !== undefined) {
+                if (this._includeProperty(field, val) && val !== undefined) {
                     var prevFieldVal = formFieldProps[name];
                     if (prevFieldVal !== undefined) { // combine values for inputs of same name
                         formFieldProps[name] = [].concat(prevFieldVal, val);

--- a/src/ce.js
+++ b/src/ce.js
@@ -41,7 +41,7 @@ var ce = {
         };
 
         var form_field_value = this._getFormFieldValue(elem);
-        if (_.includes(['input', 'select', 'textarea'], elem.tagName.toLowerCase()) && form_field_value !== '[stripped]') {
+        if (_.includes(['input', 'select', 'textarea'], elem.tagName.toLowerCase()) && this._includeProperty(elem, value)) {
             props[ 'value'] = form_field_value;
         }
 
@@ -133,28 +133,26 @@ var ce = {
         return value;
     },
 
-    _sanitizeInputValue: function(input, value) {
+    _includeProperty: function(input, value) {
         var classes = (input.className || '').split(' ');
-        if (_.includes(classes, 'mp-never-strip-value')) { // never sanitize inputs with class "mp-never-strip-value"
-            return value;
-        } else if (_.includes(classes, 'mp-always-strip-value')) { // always sanitize fields with class "mp-always-strip-value"
-            return '[stripped]';
+        if (_.includes(classes, 'mp-always-include-value')) { // never sanitize inputs with class "mp-never-strip-value"
+            return true;
         }
 
         // don't include hidden or password fields
         var type = input.type || '';
         switch(type.toLowerCase()) {
             case 'hidden':
-                return '[stripped]';
+                return false;
             case 'password':
-                return '[stripped]';
+                return false;
         }
 
         // filter out data from fields that look like sensitive fields
         var name = input.name || input.id || '';
         var sensitiveNameRegex = /^cc|cardnum|ccnum|creditcard|csc|cvc|cvv|exp|pass|seccode|securitycode|securitynum|socialsec|socsec|ssn/i;
         if (sensitiveNameRegex.test(name.replace(/[^a-zA-Z0-9]/g, ''))) {
-            return '[stripped]';
+            return false;
         }
 
         if (typeof value === 'string') {
@@ -162,18 +160,18 @@ var ce = {
             // see: https://www.safaribooksonline.com/library/view/regular-expressions-cookbook/9781449327453/ch04s20.html
             var ccRegex = /^(?:(4[0-9]{12}(?:[0-9]{3})?)|(5[1-5][0-9]{14})|(6(?:011|5[0-9]{2})[0-9]{12})|(3[47][0-9]{13})|(3(?:0[0-5]|[68][0-9])[0-9]{11})|((?:2131|1800|35[0-9]{3})[0-9]{11}))$/;
             if (ccRegex.test((value || '').replace(/[\- ]/g, ''))) {
-                return '[stripped]';
+                return false;
             }
 
             // check to see if input value looks like a social security number
             var ssnRegex = /(^\d{3}-?\d{2}-?\d{4}$)/;
             if (ssnRegex.test(value)) {
-                return '[stripped]';
+                return false;
             }
         }
 
         // return unmodified value
-        return value;
+        return true;
     },
 
     _getFormFieldValue: function(field) {
@@ -189,7 +187,7 @@ var ce = {
                 val = field.value || field.textContent;
                 break;
         }
-        return this._sanitizeInputValue(field, val);
+        return val;
     },
 
     _getFormFieldProperties: function(form) {
@@ -199,7 +197,7 @@ var ce = {
             if (name !== null) {
                 name = '$form_field__' + name;
                 var val = this._getFormFieldValue(field);
-                if (val !== undefined && val !== '[stripped]') {
+                if (this._includeProperty(field, value) && val !== undefined) {
                     var prevFieldVal = formFieldProps[name];
                     if (prevFieldVal !== undefined) { // combine values for inputs of same name
                         formFieldProps[name] = [].concat(prevFieldVal, val);

--- a/src/ce.js
+++ b/src/ce.js
@@ -41,7 +41,7 @@ var ce = {
         };
 
         var formFieldValue = this._getFormFieldValue(elem);
-        if (_.includes(['input', 'select', 'textarea'], elem.tagName.toLowerCase()) && this._includeProperty(elem, formFieldValue)) {
+        if (_.includes(['input', 'select', 'textarea'], elem.tagName.toLowerCase()) && formFieldValue !== null) {
             props['value'] = formFieldValue;
         }
 
@@ -186,7 +186,7 @@ var ce = {
                 val = field.value || field.textContent;
                 break;
         }
-        return val;
+        return this._includeProperty(field, val) ? val : null;
     },
 
     _getFormFieldProperties: function(form) {
@@ -196,7 +196,7 @@ var ce = {
             if (name !== null) {
                 name = '$form_field__' + name;
                 var val = this._getFormFieldValue(field);
-                if (this._includeProperty(field, val) && val !== undefined) {
+                if (val !== undefined && val !== null) {
                     var prevFieldVal = formFieldProps[name];
                     if (prevFieldVal !== undefined) { // combine values for inputs of same name
                         formFieldProps[name] = [].concat(prevFieldVal, val);

--- a/tests/unit/testCE.js
+++ b/tests/unit/testCE.js
@@ -135,12 +135,12 @@ describe('Collect Everything system', function() {
 
     it('should strip hidden input value', function() {
       const props = ce._getPropertiesFromElement(hidden);
-      expect(props['value']).to.equal('[stripped]');
+      expect(props['value']).to.equal(undefined);
     });
 
     it('should strip password input value', function() {
       const props = ce._getPropertiesFromElement(password);
-      expect(props['value']).to.equal('[stripped]');
+      expect(props['value']).to.equal(undefined);
     });
 
     it('should contain nth-of-type', function() {
@@ -213,37 +213,37 @@ describe('Collect Everything system', function() {
     });
   });
 
-  describe('_sanitizeInputValue', function() {
+  describe('_includeProperty', function() {
     let input;
 
     beforeEach(function() {
       input = document.createElement('input');
     });
 
-    it('should never sanitize inputs with class "mp-never-strip-value"', function() {
+    it('should never sanitize inputs with class "mp-always-include-value"', function() {
       input.type = 'password';
-      input.className = 'test1 mp-never-strip-value test2';
+      input.className = 'test1 mp-always-include-value test2';
       input.value = 'force included password';
-      expect(ce._sanitizeInputValue(input, input.value)).to.equal('force included password');
+      expect(ce._includeProperty(input, input.value)).to.equal(true);
     });
 
     it('should sanitize inputs with class "mp-always-strip-value"', function() {
       input.type = 'text';
       input.className = 'test1 mp-always-strip-value test2';
       input.value = 'force sanitized';
-      expect(ce._sanitizeInputValue(input, input.value)).to.equal('[stripped]');
+      expect(ce._includeProperty(input, input.value)).to.equal(false);
     });
 
     it('should sanitize hidden fields', function() {
       input.type = 'hidden';
       input.value = 'hidden val';
-      expect(ce._sanitizeInputValue(input, input.value)).to.equal('[stripped]');
+      expect(ce._includeProperty(input, input.value)).to.equal(false);
     });
 
     it('should sanitize password fields', function() {
       input.type = 'password';
       input.value = 'password val';
-      expect(ce._sanitizeInputValue(input, input.value)).to.equal('[stripped]');
+      expect(ce._includeProperty(input, input.value)).to.equal(false);
     });
 
     it('should sanitize fields with sensitive names', function() {
@@ -267,7 +267,7 @@ describe('Collect Everything system', function() {
       input.value = 'should be strippedl';
       sensitiveNames.forEach(name => {
         input.name = name;
-        expect(ce._sanitizeInputValue(input, input.value)).to.equal('[stripped]');
+        expect(ce._includeProperty(input, input.value)).to.equal(false);
       });
     });
 
@@ -276,20 +276,20 @@ describe('Collect Everything system', function() {
       // one for each type on http://www.getcreditcardnumbers.com/
       const validCCNumbers = ['3419-881002-84912', '30148420855976', '5183792099737678', '6011-5100-8788-7057', '180035601937848', '180072512946394', '4556617778508'];
       validCCNumbers.forEach(num => {
-        expect(ce._sanitizeInputValue(input, num)).to.equal('[stripped]');
+        expect(ce._includeProperty(input, num)).to.equal(false);
       });
     });
 
     it('should strip social security numbers', function() {
       input.type = 'text';
       input.value = '123-45-6789';
-      expect(ce._sanitizeInputValue(input, input.value)).to.equal('[stripped]');
+      expect(ce._includeProperty(input, input.value)).to.equal(false);
     });
 
     it('should return the original value for non-sensitive inputs', function() {
       input.type = 'text';
       input.value = 'Josh';
-      expect(ce._sanitizeInputValue(input, input.value)).to.equal('Josh');
+      expect(ce._includeProperty(input, input.value)).to.equal(true);
     });
 
     it('should return the original value for multi selects', function() {
@@ -303,7 +303,7 @@ describe('Collect Everything system', function() {
       select.appendChild(option2);
       option1.setAttribute('selected', true);
       option2.setAttribute('selected', true);
-      expect(ce._sanitizeInputValue(input, ce._getSelectValue(select))).to.deep.equal(['1', '2']);
+      expect(ce._includeProperty(input, ce._getSelectValue(select))).to.equal(true);
     });
   });
 

--- a/tests/unit/testCE.js
+++ b/tests/unit/testCE.js
@@ -220,7 +220,7 @@ describe('Collect Everything system', function() {
       input = document.createElement('input');
     });
 
-    it('should never sanitize inputs with class "mp-always-include-value"', function() {
+    it('should always include inputs with class "mp-always-include-value"', function() {
       input.type = 'password';
       input.className = 'test1 mp-always-include-value test2';
       input.value = 'force included password';


### PR DESCRIPTION
https://mixpanel.atlassian.net/browse/CA-816
if the value of the property would be '[stripped]' just don't add that prop

key changes: 
_getFormFieldValue will always return the value now -- but when we would add a property or its value we now check first to see if _includeProperty is true