### PR TITLE
Added register_page_lifecycle function

### DIFF
--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -452,6 +452,20 @@ MixpanelPersistence.prototype.register = function(props, days) {
     return false;
 };
 
+/**
+ * Registers a property that stays during the webpage lifecycle, getting cleared
+ * upon navigation or refresh
+ *
+ * @param {Object} props
+ */
+MixpanelPersistence.prototype.register_page_lifecycle = function(props) {
+    if (!_.isObject(props)) {
+        return false;
+    }
+    _.extend(this['props'], props);
+    return true;
+};
+
 MixpanelPersistence.prototype.unregister = function(prop) {
     if (prop in this['props']) {
         delete this['props'][prop];

--- a/tests/test.js
+++ b/tests/test.js
@@ -1209,6 +1209,18 @@
                 same(get_props_without_distinct_id(mixpanel.test), props, "properties set properly");
             });
 
+            test('register_page_lifecycle', 3, function() {
+                var props = {
+                    'hi': 'there'
+                };
+
+                same(get_props_without_distinct_id(mixpanel.test), {}, "empty before setting");
+
+                mixpanel.test.register_page_lifecycle(props);
+
+                same(get_props_without_distinct_id(mixpanel.test), props, "properties set properly");
+            });
+
             test("register_once", 3, function() {
                 var props = {
                         'hi': 'there'


### PR DESCRIPTION
This function registers super properties that will be present in all subsequent `track` calls during the page lifecycle, getting reset upon page navigation.

Solves https://github.com/mixpanel/mixpanel-js/issues/109