### PR TITLE
Moved referrer_info to set_once for people

### DIFF
--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -1620,18 +1620,6 @@ MixpanelPeople.prototype.set = function(prop, to, callback) {
         $set[prop] = to;
     }
 
-    // make sure that the referrer info has been updated and saved
-    if (this._get_config('save_referrer')) {
-        this._mixpanel['persistence'].update_referrer_info(document.referrer);
-    }
-
-    // update $set object with default people properties
-    $set = _.extend(
-        {},
-        _.info.people_properties(),
-        this._mixpanel['persistence'].get_referrer_info(),
-        $set
-    );
 
     data[SET_ACTION] = $set;
 
@@ -1672,6 +1660,20 @@ MixpanelPeople.prototype.set_once = function(prop, to, callback) {
     } else {
         $set_once[prop] = to;
     }
+
+    // make sure that the referrer info has been updated and saved
+    if (this._get_config('save_referrer')) {
+        this._mixpanel['persistence'].update_referrer_info(document.referrer);
+    }
+
+    // update $set object with default people properties
+    $set = _.extend(
+        {},
+        _.info.people_properties(),
+        this._mixpanel['persistence'].get_referrer_info(),
+        $set
+    );
+
     data[SET_ONCE_ACTION] = $set_once;
     return this._send_request(data, callback);
 };


### PR DESCRIPTION
This should keep initial referring domain and initial referrer from being updated in user profiles when they clear their cookies, switch browsers or change devices.