### PR TITLE
use global var to prevent autotrack editor from loading more than once

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "morgan": "^1.5.2",
     "node-localstorage": "^1.3.0",
     "precommit-hook": "^3.0.0",
-    "rollup": "^0.25.4",
+    "rollup": "^0.25.8",
     "rollup-plugin-npm": "^1.4.0",
     "sinon": "^1.17.3",
     "webpack": "^1.12.2"

--- a/src/autotrack.js
+++ b/src/autotrack.js
@@ -468,11 +468,9 @@ var autotrack = {
         }
     },
 
-    // only load the codeless event editor once, even if there are multiple instances of MixpanelLib
-    _editorLoaded: false,
     _loadEditor: function(instance, editorParams) {
-        if (!this._editorLoaded) {
-            this._editorLoaded = true;
+        if (!window._mpEditorLoaded) { // only load the codeless event editor once, even if there are multiple instances of MixpanelLib
+            window._mpEditorLoaded = true;
             var editorUrl;
             var cacheBuster = '?_ts=' + (new Date()).getTime();
             var siteMedia = instance.get_config('app_host') + '/site_media';

--- a/src/utils.js
+++ b/src/utils.js
@@ -383,7 +383,7 @@ _.JSONEncode = (function() {
     return function(mixed_val) {
         var value = mixed_val;
         var quote = function(string) {
-            var escapable = /[\\\"\x00-\x1f\x7f-\x9f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g;
+            var escapable = /[\\\"\x00-\x1f\x7f-\x9f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g; // eslint-disable-line no-control-regex
             var meta = { // table of character substitutions
                 '\b': '\\b',
                 '\t': '\\t',


### PR DESCRIPTION
`this` is _usually_ a singleton instance but if a website uses a modular version of Mixpanel it doesn't have to be and the autotrack editor can get loaded twice. This PR uses window to ensure a singleton instance.