### PR TITLE
ensure nodejs compatibility in compile time

### DIFF
--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -1,6 +1,6 @@
 /* eslint camelcase: "off" */
 import Config from './config';
-import { _, console, userAgent } from './utils';
+import { _, console, userAgent, window, document } from './utils';
 import { autotrack } from './autotrack';
 
 /*

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,7 +5,8 @@ import Config from './config';
 var win;
 if (typeof(window) === 'undefined') {
     win = {
-        navigator: {}
+        navigator: { userAgent: '' },
+        document: { location: {} }
     };
 } else {
     win = window;
@@ -1547,4 +1548,4 @@ _['info']['device']     = _.info.device;
 _['info']['browser']    = _.info.browser;
 _['info']['properties'] = _.info.properties;
 
-export { _, userAgent, console };
+export { _, userAgent, console, win as window, document };


### PR DESCRIPTION
utils.js says in https://github.com/mixpanel/mixpanel-js/blob/v2.12.0/src/utils.js#L4

> since es6 imports are static and we run unit tests from the console, window won't be defined when importing this file
 
but in fact, the bundled js doesn't compile with NodeJS.

This PR fixes the issue by defining browser specific symbols.

NOTE: this PR does not include changes to generated files.