### PR TITLE
Update super property check for register_once

### DIFF
--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -422,7 +422,7 @@ MixpanelPersistence.prototype.register_once = function(props, default_value, day
         this.expire_days = (typeof(days) === 'undefined') ? this.default_expiry : days;
 
         _.each(props, function(val, prop) {
-            if (!this['props'][prop] || this['props'][prop] === default_value) {
+            if (!this['props'].hasOwnProperty(prop) || this['props'][prop] === default_value) {
                 this['props'][prop] = val;
             }
         }, this);


### PR DESCRIPTION
Current implementation that checks whether a super property is already set for register_once does not account for falsy values (false, 0, null). i.e. if the super property is set to 'false' (or any other falsy value), register_once incorrectly overwrites that value
Updated code will check for whether the super property is set