### PR TITLE
Ignore examples when publishing to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
+examples
 tests
 vendor


### PR DESCRIPTION
This folder takes up ~50MB in the published package.

I noticed this when trying to deploy to Lambda, where your deployment payload can't be larger than 50MB.

<img width="390" alt="screen shot 2018-02-07 at 12 50 01" src="https://user-images.githubusercontent.com/189580/35917275-6e40c3a6-0c05-11e8-8ff2-ff72180c7f31.png">
