### PR TITLE
Clean up handling of _.JSONDecode errors.

### DIFF
--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -950,7 +950,14 @@ MixpanelLib.prototype._send_request = function(url, data, callback) {
                     if (req.status === 200) {
                         if (callback) {
                             if (verbose_mode) {
-                                callback(_.JSONDecode(req.responseText));
+                                var response;
+                                try {
+                                    response = _.JSONDecode(req.responseText);
+                                } catch (e) {
+                                    console.error(e);
+                                    return;
+                                }
+                                callback(response);
                             } else {
                                 callback(Number(req.responseText));
                             }

--- a/src/utils.js
+++ b/src/utils.js
@@ -530,12 +530,10 @@ _.JSONDecode = (function() { // https://github.com/douglascrockford/JSON-js/blob
         },
         text,
         error = function(m) {
-            throw {
-                name: 'SyntaxError',
-                message: m,
-                at: at,
-                text: text
-            };
+            var e = new SyntaxError(m);
+            e.at = at;
+            e.text = text;
+            throw e;
         },
         next = function(c) {
             // If a c parameter is provided, verify that it matches the current character.


### PR DESCRIPTION
Throw a proper error object, and make sure to catch and log it in the `onreadystatechange` callback so it doesn't propagate to the top level.

Fixes https://github.com/mixpanel/mixpanel-js/issues/169