### PR TITLE
Don't opt out of tracking by default when user has opted in

### DIFF
--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -1675,7 +1675,7 @@ MixpanelLib.prototype._init_gdpr_persistence = function() {
     }
 
     // check whether we should opt out by default and update persistence accordingly
-    if (this.get_config('opt_out_tracking_by_default') || _.cookie.get('mp_optout')) {
+    if ((!this.has_opted_in_tracking() && this.get_config('opt_out_tracking_by_default')) || _.cookie.get('mp_optout')) {
         _.cookie.remove('mp_optout');
         this.opt_out_tracking();
     }

--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -1675,7 +1675,8 @@ MixpanelLib.prototype._init_gdpr_persistence = function() {
     }
 
     // check whether we should opt out by default and update persistence accordingly
-    if ((!this.has_opted_in_tracking() && this.get_config('opt_out_tracking_by_default')) || _.cookie.get('mp_optout')) {
+    var should_default_out = !this.has_opted_in_tracking() && this.get_config('opt_out_tracking_by_default');
+    if (should_default_out || _.cookie.get('mp_optout')) {
         _.cookie.remove('mp_optout');
         this.opt_out_tracking();
     }


### PR DESCRIPTION
It's been requested that 'opt_out_tracking_by_default' does not opt out users who have opted in via cookies, etc.. Going to double check this code with Evan when he gets back