### PR TITLE
add optional navigator.sendBeacon transport

### DIFF
--- a/doc/readme.io/javascript-full-api-reference.md
+++ b/doc/readme.io/javascript-full-api-reference.md
@@ -367,6 +367,18 @@ The default config is:
 
 ```javascript
 {
+  // HTTP method for tracking requests
+  api_method: 'POST'
+
+  // transport for sending requests ('XHR' or 'sendBeacon')
+  // NB: sendBeacon should only be used for scenarios such as
+  // page unload where a &quot;best-effort&quot; attempt to send is
+  // acceptable; the sendBeacon API does not support callbacks
+  // or any way to know the result of the request. Mixpanel
+  // tracking via sendBeacon will not support any event-
+  // batching or retry mechanisms.
+  api_transport: 'XHR'
+
   // super properties cookie expiration (in days)
   cookie_expiration: 365
 
@@ -504,6 +516,9 @@ Track an event. This is the most important and  frequently used Mixpanel functio
 // track an event named 'Registered'
 mixpanel.track('Registered', {'Gender': 'Male', 'Age': 21});
 
+// track an event using navigator.sendBeacon
+mixpanel.track('Left page', {'duration_seconds': 35}, {transport: 'sendBeacon'});
+
 ```
 To track link clicks or form submissions, see track_links() or track_forms().
 
@@ -513,6 +528,8 @@ To track link clicks or form submissions, see track_links() or track_forms().
 | ------------- | ------------- | ----- |
 | **event_name** | <span class="mp-arg-type">String</span></br></span><span class="mp-arg-required">required</span> | The name of the event. This can be anything the user does - 'Button Click', 'Sign Up', 'Item Purchased', etc. |
 | **properties** | <span class="mp-arg-type">Object</span></br></span><span class="mp-arg-optional">optional</span> | A set of properties to include with the event you're sending. These describe the user who did the event or details about the event itself. |
+| **options** | <span class="mp-arg-type">Object</span></br></span><span class="mp-arg-optional">optional</span> | Optional configuration for this track request. |
+| **options.transport** | <span class="mp-arg-type">String</span></br></span><span class="mp-arg-optional">optional</span> | Transport method for network request ('xhr' or 'sendBeacon'). |
 | **callback** | <span class="mp-arg-type">Function</span></br></span><span class="mp-arg-optional">optional</span> | If provided, the callback function will be called after tracking the event. |
 
 

--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -554,6 +554,9 @@ MixpanelLib.prototype.disable = function(events) {
  *     // track an event named 'Registered'
  *     mixpanel.track('Registered', {'Gender': 'Male', 'Age': 21});
  *
+ *     // track an event using navigator.sendBeacon
+ *     mixpanel.track('Left page', {'duration_seconds': 35}, {transport: 'sendBeacon'});
+ *
  * To track link clicks or form submissions, see track_links() or track_forms().
  *
  * @param {String} event_name The name of the event. This can be anything the user does - 'Button Click', 'Sign Up', 'Item Purchased', etc.

--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -1116,6 +1116,18 @@ MixpanelLib.prototype.name_tag = function(name_tag) {
  * The default config is:
  *
  *     {
+ *       // HTTP method for tracking requests
+ *       api_method: 'POST'
+ *
+ *       // transport for sending requests ('XHR' or 'sendBeacon')
+ *       // NB: sendBeacon should only be used for scenarios such as
+ *       // page unload where a "best-effort" attempt to send is
+ *       // acceptable; the sendBeacon API does not support callbacks
+ *       // or any way to know the result of the request. Mixpanel
+ *       // tracking via sendBeacon will not support any event-
+ *       // batching or retry mechanisms.
+ *       api_transport: 'XHR'
+ *
  *       // super properties cookie expiration (in days)
  *       cookie_expiration: 365
  *

--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -344,7 +344,7 @@ MixpanelLib.prototype._send_request = function(url, data, options, callback) {
 
     var DEFAULT_OPTIONS = {
         method: this.get_config('api_method'),
-        transport: this.get_config('api_transport'),
+        transport: this.get_config('api_transport')
     };
     var body_data = null;
 

--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -78,6 +78,7 @@ if (sendBeacon) {
 var DEFAULT_CONFIG = {
     'api_host':                          'https://api-js.mixpanel.com',
     'api_method':                        'POST',
+    'api_transport':                     'XHR',
     'app_host':                          'https://mixpanel.com',
     'autotrack':                         true,
     'cdn':                               'https://cdn.mxpnl.com',
@@ -341,7 +342,10 @@ MixpanelLib.prototype._send_request = function(url, data, options, callback) {
         return;
     }
 
-    var DEFAULT_OPTIONS = {method: this.get_config('api_method')};
+    var DEFAULT_OPTIONS = {
+        method: this.get_config('api_method'),
+        transport: this.get_config('api_transport'),
+    };
     var body_data = null;
 
     if (!callback && (_.isFunction(options) || typeof options === 'string')) {
@@ -352,7 +356,7 @@ MixpanelLib.prototype._send_request = function(url, data, options, callback) {
     if (!USE_XHR) {
         options.method = 'GET';
     }
-    var use_sendBeacon = sendBeacon && (options['transport'] || '').toLowerCase() === 'sendbeacon';
+    var use_sendBeacon = sendBeacon && options.transport.toLowerCase() === 'sendbeacon';
     var use_post = use_sendBeacon || options.method === 'POST';
 
     // needed to correctly format responses
@@ -563,6 +567,10 @@ MixpanelLib.prototype.track = addOptOutCheckMixpanelLib(function(event_name, pro
         options = null;
     }
     options = options || {};
+    var transport = options['transport'];
+    if (transport) {
+        options.transport = transport;
+    }
     if (!_.isFunction(callback)) {
         callback = function() {};
     }

--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -67,6 +67,7 @@ var USE_XHR = (window.XMLHttpRequest && 'withCredentials' in new XMLHttpRequest(
 // should only be true for Opera<12
 var ENQUEUE_REQUESTS = !USE_XHR && (userAgent.indexOf('MSIE') === -1) && (userAgent.indexOf('Mozilla') === -1);
 
+// save reference to navigator.sendBeacon so it can be minified
 var sendBeacon = navigator['sendBeacon'];
 if (sendBeacon) {
     sendBeacon = _.bind(sendBeacon, navigator);
@@ -567,9 +568,9 @@ MixpanelLib.prototype.track = addOptOutCheckMixpanelLib(function(event_name, pro
         options = null;
     }
     options = options || {};
-    var transport = options['transport'];
+    var transport = options['transport']; // external API, don't minify 'transport' prop
     if (transport) {
-        options.transport = transport;
+        options.transport = transport; // 'transport' prop name can be minified internally
     }
     if (!_.isFunction(callback)) {
         callback = function() {};

--- a/src/utils.js
+++ b/src/utils.js
@@ -1613,4 +1613,4 @@ _['info']['device']     = _.info.device;
 _['info']['browser']    = _.info.browser;
 _['info']['properties'] = _.info.properties;
 
-export { _, userAgent, console, win as window, document };
+export { _, userAgent, console, win as window, document, navigator };

--- a/tests/test.js
+++ b/tests/test.js
@@ -3531,6 +3531,14 @@
                 });
             }
 
+            if (navigator.sendBeacon) {
+                mpmodule("sendBeacon tests");
+                test("sendBeacon option supported in .track()", 1, function() {
+                    var data = mixpanel.test.track("test_sendbeacon", {}, {transport: 'sendBeacon'});
+                    same(data['event'], 'test_sendbeacon');
+                });
+            }
+
             if (USE_XHR) {
                 mpmodule("xhr tests", startRecordingXhrRequests, stopRecordingXhrRequests);
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -3533,8 +3533,15 @@
 
             if (navigator.sendBeacon) {
                 mpmodule("sendBeacon tests");
+
                 test("sendBeacon option supported in .track()", 1, function() {
                     var data = mixpanel.test.track("test_sendbeacon", {}, {transport: 'sendBeacon'});
+                    same(data['event'], 'test_sendbeacon');
+                });
+
+                test("sendBeacon supported in library config", 1, function() {
+                    mixpanel.test.set_config({api_transport: 'sendBeacon'});
+                    var data = mixpanel.test.track("test_sendbeacon", {});
                     same(data['event'], 'test_sendbeacon');
                 });
             }


### PR DESCRIPTION
fixes https://github.com/mixpanel/mixpanel-js/issues/184

Several ways to use it:
```js
// for an individual track() call
mixpanel.track('my event', {my: 'props'}, {transport: 'sendBeacon'});

// turn on for every Mixpanel call when page is unloading
// (you would use this to use sendBeacon for everything, including
// mixpanel.people calls)
window.addEventListener(`unload`, function() {
  mixpanel.set_config({api_transport: 'sendBeacon'});
  mixpanel.track('my event');
  mixpanel.people.set({foo: 'bar'});
});

// initialize for all tracking; not recommended as it will prevent any
// request-retry facilities
mixpanel.init('my token', {api_transport: 'sendBeacon'});
mixpanel.track('my event');
```