### PR TITLE
Fix arrow-function track() callbacks not executing

### DIFF
--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -566,7 +566,7 @@ MixpanelLib.prototype.disable = function(events) {
  * @param {Function} [callback] If provided, the callback function will be called after tracking the event.
  */
 MixpanelLib.prototype.track = addOptOutCheckMixpanelLib(function(event_name, properties, options, callback) {
-    if (!callback && _.isFunction(options)) {
+    if (!callback && typeof options === 'function') {
         callback = options;
         options = null;
     }
@@ -575,7 +575,7 @@ MixpanelLib.prototype.track = addOptOutCheckMixpanelLib(function(event_name, pro
     if (transport) {
         options.transport = transport; // 'transport' prop name can be minified internally
     }
-    if (!_.isFunction(callback)) {
+    if (typeof callback !== 'function') {
         callback = function() {};
     }
 


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/mixpanel/mixpanel-js/pull/240: the _.isFunction() check in utils.js doesn't handle arrow functions correctly, so arrow func track callbacks weren't getting called. Simply reverting to the previous `typeof` check for now to get out of trouble without changing the browser compatibility story. We'll need to revisit whether the `_.isFunction()` implementation is useful at all anymore (for instance we don't realistically need to defend against the case of somebody passing a RegEx as the third param of `track()`).