### PR TITLE
sendBeacon vs GET fix

### DIFF
--- a/src/autotrack.js
+++ b/src/autotrack.js
@@ -240,7 +240,7 @@ var autotrack = {
                     'lib': 'web',
                     'token': token
                 },
-                {method: 'GET'},
+                {method: 'GET', transport: 'XHR'},
                 instance._prepare_callback(parseDecideResponse)
             );
         }

--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -357,8 +357,8 @@ MixpanelLib.prototype._send_request = function(url, data, options, callback) {
     if (!USE_XHR) {
         options.method = 'GET';
     }
-    var use_sendBeacon = sendBeacon && options.method !== 'GET' && options.transport.toLowerCase() === 'sendbeacon';
-    var use_post = use_sendBeacon || options.method === 'POST';
+    var use_post = options.method === 'POST';
+    var use_sendBeacon = sendBeacon && use_post && options.transport.toLowerCase() === 'sendbeacon';
 
     // needed to correctly format responses
     var verbose_mode = this.get_config('verbose');

--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -1307,7 +1307,7 @@ MixpanelLib.prototype._check_and_handle_notifications = addOptOutCheckMixpanelLi
     this._send_request(
         this.get_config('api_host') + '/decide/',
         data,
-        {method: 'GET'},
+        {method: 'GET', transport: 'XHR'},
         this._prepare_callback(_.bind(function(result) {
             if (result['notifications'] && result['notifications'].length > 0) {
                 this['_triggered_notifs'] = [];

--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -357,7 +357,7 @@ MixpanelLib.prototype._send_request = function(url, data, options, callback) {
     if (!USE_XHR) {
         options.method = 'GET';
     }
-    var use_sendBeacon = sendBeacon && options.transport.toLowerCase() === 'sendbeacon';
+    var use_sendBeacon = sendBeacon && options.method !== 'GET' && options.transport.toLowerCase() === 'sendbeacon';
     var use_post = use_sendBeacon || options.method === 'POST';
 
     // needed to correctly format responses

--- a/tests/test.js
+++ b/tests/test.js
@@ -3676,6 +3676,23 @@
                         'GET request should not have transmitted data in request body'
                     );
                 });
+
+                if (navigator.sendBeacon) {
+                    test("specifying GET overrides sendBeacon transport", 3, function() {
+                        mixpanel.test.set_config({api_method: 'GET', api_transport: 'sendBeacon'});
+
+                        mixpanel.test.track('test', {foo: 'bar'});
+
+                        same(this.requests.length, 1, "track should have fired off a request");
+
+                        var req = this.requests[0];
+                        same(req.method, 'GET');
+                        ok(
+                            req.url.indexOf('data=') >= 0,
+                            'GET request should have transmitted data on URL'
+                        );
+                    });
+                }
             }
 
             if (!window.COOKIE_FAILURE_TEST) { // GDPR functionality cannot operate without cookies


### PR DESCRIPTION
Since POST is the default method, GET can be considered an override
that turns off sendBeacon (which is POST-only). Mainly this makes sure
that /decide requests are always GET.

fixes https://github.com/mixpanel/mixpanel-js/issues/244