### PR TITLE
Adjust regex for cross subdomain

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -44,7 +44,7 @@ var nativeBind = FuncProto.bind,
     nativeIsArray = Array.isArray,
     breaker = {};
 
-var DOMAIN_MATCH_REGEX = /[a-z0-9][a-z0-9-]+\.[a-z.]{2,6}$/i;
+var DOMAIN_MATCH_REGEX = /[a-z0-9][a-z0-9-]+\.[a-z]{2,6}$/i;
 
 var _ = {
     trim: function(str) {


### PR DESCRIPTION
Adjusting the regular expression used to fetch the domain since the previous one did not work with 2 letter domains, like ab.com