### PR TITLE
cookie options and improvements for cross-subdomain and cross-site cookies

### DIFF
--- a/src/gdpr-utils.js
+++ b/src/gdpr-utils.js
@@ -35,6 +35,8 @@ var GDPR_DEFAULT_PERSISTENCE_PREFIX = '__mp_opt_in_out_';
  * @param {string} [options.persistenceType] Persistence mechanism used - cookie or localStorage
  * @param {string} [options.persistencePrefix=__mp_opt_in_out] - custom prefix to be used in the cookie/localstorage name
  * @param {Number} [options.cookieExpiration] - number of days until the opt-in cookie expires
+ * @param {string} [options.cookieDomain] - custom cookie domain
+ * @param {boolean} [options.crossSiteCookie] - whether the opt-in cookie is set as cross-site-enabled
  * @param {boolean} [options.crossSubdomainCookie] - whether the opt-in cookie is set as cross-subdomain or not
  * @param {boolean} [options.secureCookie] - whether the opt-in cookie is set as secure or not
  */
@@ -49,6 +51,8 @@ export function optIn(token, options) {
  * @param {string} [options.persistenceType] Persistence mechanism used - cookie or localStorage
  * @param {string} [options.persistencePrefix=__mp_opt_in_out] - custom prefix to be used in the cookie/localstorage name
  * @param {Number} [options.cookieExpiration] - number of days until the opt-out cookie expires
+ * @param {string} [options.cookieDomain] - custom cookie domain
+ * @param {boolean} [options.crossSiteCookie] - whether the opt-in cookie is set as cross-site-enabled
  * @param {boolean} [options.crossSubdomainCookie] - whether the opt-out cookie is set as cross-subdomain or not
  * @param {boolean} [options.secureCookie] - whether the opt-out cookie is set as secure or not
  */
@@ -130,12 +134,16 @@ export function addOptOutCheckMixpanelGroup(method) {
  * @param {string} [options.persistenceType] Persistence mechanism used - cookie or localStorage
  * @param {string} [options.persistencePrefix=__mp_opt_in_out] - custom prefix to be used in the cookie/localstorage name
  * @param {Number} [options.cookieExpiration] - number of days until the opt-in cookie expires
+ * @param {string} [options.cookieDomain] - custom cookie domain
+ * @param {boolean} [options.crossSiteCookie] - whether the opt-in cookie is set as cross-site-enabled
  * @param {boolean} [options.crossSubdomainCookie] - whether the opt-in cookie is set as cross-subdomain or not
  * @param {boolean} [options.secureCookie] - whether the opt-in cookie is set as secure or not
  */
 export function clearOptInOut(token, options) {
     options = options || {};
-    _getStorage(options).remove(_getStorageKey(token, options), !!options.crossSubdomainCookie);
+    _getStorage(options).remove(
+        _getStorageKey(token, options), !!options.crossSubdomainCookie, options.cookieDomain
+    );
 }
 
 /** Private **/
@@ -212,6 +220,8 @@ function _hasDoNotTrackFlagOn(options) {
  * @param {Object} [options.trackProperties] - set of properties to be tracked along with the opt-in action
  * @param {string} [options.persistencePrefix=__mp_opt_in_out] - custom prefix to be used in the cookie/localstorage name
  * @param {Number} [options.cookieExpiration] - number of days until the opt-in cookie expires
+ * @param {string} [options.cookieDomain] - custom cookie domain
+ * @param {boolean} [options.crossSiteCookie] - whether the opt-in cookie is set as cross-site-enabled
  * @param {boolean} [options.crossSubdomainCookie] - whether the opt-in cookie is set as cross-subdomain or not
  * @param {boolean} [options.secureCookie] - whether the opt-in cookie is set as secure or not
  */
@@ -228,7 +238,9 @@ function _optInOut(optValue, token, options) {
         optValue ? 1 : 0,
         _.isNumber(options.cookieExpiration) ? options.cookieExpiration : null,
         !!options.crossSubdomainCookie,
-        !!options.secureCookie
+        !!options.secureCookie,
+        !!options.crossSiteCookie,
+        options.cookieDomain
     );
 
     if (options.track && optValue) { // only track event if opting in (optValue=true)

--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -83,6 +83,7 @@ var DEFAULT_CONFIG = {
     'app_host':                          'https://mixpanel.com',
     'autotrack':                         true,
     'cdn':                               'https://cdn.mxpnl.com',
+    'cross_site_cookie':                 false,
     'cross_subdomain_cookie':            true,
     'persistence':                       'cookie',
     'persistence_name':                  '',
@@ -1142,6 +1143,11 @@ MixpanelLib.prototype.name_tag = function(name_tag) {
  *
  *       // super properties cookie expiration (in days)
  *       cookie_expiration: 365
+ *
+ *       // if true, cookie will be set with SameSite=None; Secure
+ *       // this is only useful in special situations, like embedded
+ *       // 3rd-party iframes that set up a Mixpanel instance
+ *       cross_site_cookie: false
  *
  *       // super properties span subdomains
  *       cross_subdomain_cookie: true

--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -86,6 +86,7 @@ var DEFAULT_CONFIG = {
     'cross_subdomain_cookie':            true,
     'persistence':                       'cookie',
     'persistence_name':                  '',
+    'cookie_domain':                     '',
     'cookie_name':                       '',
     'loaded':                            function() {},
     'store_google':                      true,
@@ -1132,6 +1133,12 @@ MixpanelLib.prototype.name_tag = function(name_tag) {
  *       // tracking via sendBeacon will not support any event-
  *       // batching or retry mechanisms.
  *       api_transport: 'XHR'
+ *
+ *       // override value for cookie domain, only useful for ensuring
+ *       // correct cross-subdomain cookies on unusual domains like
+ *       // subdomain.mainsite.avocat.fr; NB this cannot be used to
+ *       // set cookies on a different domain than the current origin
+ *       cookie_domain: ''
  *
  *       // super properties cookie expiration (in days)
  *       cookie_expiration: 365

--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -1420,7 +1420,9 @@ MixpanelLib.prototype._gdpr_call_func = function(func, options) {
         'persistence_type': this.get_config('opt_out_tracking_persistence_type'),
         'cookie_prefix': this.get_config('opt_out_tracking_cookie_prefix'),
         'cookie_expiration': this.get_config('cookie_expiration'),
+        'cross_site_cookie': this.get_config('cross_site_cookie'),
         'cross_subdomain_cookie': this.get_config('cross_subdomain_cookie'),
+        'cookie_domain': this.get_config('cookie_domain'),
         'secure_cookie': this.get_config('secure_cookie'),
         'ignore_dnt': this.get_config('ignore_dnt')
     }, options);
@@ -1436,7 +1438,9 @@ MixpanelLib.prototype._gdpr_call_func = function(func, options) {
         trackProperties: options['track_properties'],
         persistenceType: options['persistence_type'],
         persistencePrefix: options['cookie_prefix'],
+        cookieDomain: options['cookie_domain'],
         cookieExpiration: options['cookie_expiration'],
+        crossSiteCookie: options['cross_site_cookie'],
         crossSubdomainCookie: options['cross_subdomain_cookie'],
         secureCookie: options['secure_cookie'],
         ignoreDnt: options['ignore_dnt']
@@ -1469,6 +1473,8 @@ MixpanelLib.prototype._gdpr_call_func = function(func, options) {
  * @param {string} [options.persistence_type=localStorage] Persistence mechanism used - cookie or localStorage - falls back to cookie if localStorage is unavailable
  * @param {string} [options.cookie_prefix=__mp_opt_in_out] Custom prefix to be used in the cookie/localstorage name
  * @param {Number} [options.cookie_expiration] Number of days until the opt-in cookie expires (overrides value specified in this Mixpanel instance's config)
+ * @param {string} [options.cookie_domain] Custom cookie domain (overrides value specified in this Mixpanel instance's config)
+ * @param {boolean} [options.cross_site_cookie] Whether the opt-in cookie is set as cross-site-enabled (overrides value specified in this Mixpanel instance's config)
  * @param {boolean} [options.cross_subdomain_cookie] Whether the opt-in cookie is set as cross-subdomain or not (overrides value specified in this Mixpanel instance's config)
  * @param {boolean} [options.secure_cookie] Whether the opt-in cookie is set as secure or not (overrides value specified in this Mixpanel instance's config)
  */
@@ -1501,6 +1507,8 @@ MixpanelLib.prototype.opt_in_tracking = function(options) {
  * @param {string} [options.persistence_type=localStorage] Persistence mechanism used - cookie or localStorage - falls back to cookie if localStorage is unavailable
  * @param {string} [options.cookie_prefix=__mp_opt_in_out] Custom prefix to be used in the cookie/localstorage name
  * @param {Number} [options.cookie_expiration] Number of days until the opt-in cookie expires (overrides value specified in this Mixpanel instance's config)
+ * @param {string} [options.cookie_domain] Custom cookie domain (overrides value specified in this Mixpanel instance's config)
+ * @param {boolean} [options.cross_site_cookie] Whether the opt-in cookie is set as cross-site-enabled (overrides value specified in this Mixpanel instance's config)
  * @param {boolean} [options.cross_subdomain_cookie] Whether the opt-in cookie is set as cross-subdomain or not (overrides value specified in this Mixpanel instance's config)
  * @param {boolean} [options.secure_cookie] Whether the opt-in cookie is set as secure or not (overrides value specified in this Mixpanel instance's config)
  */
@@ -1574,6 +1582,8 @@ MixpanelLib.prototype.has_opted_out_tracking = function(options) {
  * @param {string} [options.persistence_type=localStorage] Persistence mechanism used - cookie or localStorage - falls back to cookie if localStorage is unavailable
  * @param {string} [options.cookie_prefix=__mp_opt_in_out] Custom prefix to be used in the cookie/localstorage name
  * @param {Number} [options.cookie_expiration] Number of days until the opt-in cookie expires (overrides value specified in this Mixpanel instance's config)
+ * @param {string} [options.cookie_domain] Custom cookie domain (overrides value specified in this Mixpanel instance's config)
+ * @param {boolean} [options.cross_site_cookie] Whether the opt-in cookie is set as cross-site-enabled (overrides value specified in this Mixpanel instance's config)
  * @param {boolean} [options.cross_subdomain_cookie] Whether the opt-in cookie is set as cross-subdomain or not (overrides value specified in this Mixpanel instance's config)
  * @param {boolean} [options.secure_cookie] Whether the opt-in cookie is set as secure or not (overrides value specified in this Mixpanel instance's config)
  */

--- a/src/mixpanel-persistence.js
+++ b/src/mixpanel-persistence.js
@@ -157,14 +157,15 @@ MixpanelPersistence.prototype.save = function() {
         _.JSONEncode(this['props']),
         this.expire_days,
         this.cross_subdomain,
-        this.secure
+        this.secure,
+        this.cookie_domain
     );
 };
 
 MixpanelPersistence.prototype.remove = function() {
     // remove both domain and subdomain cookies
-    this.storage.remove(this.name, false);
-    this.storage.remove(this.name, true);
+    this.storage.remove(this.name, false, this.cookie_domain);
+    this.storage.remove(this.name, true, this.cookie_domain);
 };
 
 // removes the storage entry and deletes all loaded data
@@ -280,6 +281,7 @@ MixpanelPersistence.prototype.safe_merge = function(props) {
 MixpanelPersistence.prototype.update_config = function(config) {
     this.default_expiry = this.expire_days = config['cookie_expiration'];
     this.set_disabled(config['disable_persistence']);
+    this.set_cookie_domain(config['cookie_domain']);
     this.set_cross_subdomain(config['cross_subdomain_cookie']);
     this.set_secure(config['secure_cookie']);
 };
@@ -289,6 +291,14 @@ MixpanelPersistence.prototype.set_disabled = function(disabled) {
     if (this.disabled) {
         this.remove();
     } else {
+        this.save();
+    }
+};
+
+MixpanelPersistence.prototype.set_cookie_domain = function(cookie_domain) {
+    if (cookie_domain !== this.cookie_domain) {
+        this.remove();
+        this.cookie_domain = cookie_domain;
         this.save();
     }
 };

--- a/src/mixpanel-persistence.js
+++ b/src/mixpanel-persistence.js
@@ -158,6 +158,7 @@ MixpanelPersistence.prototype.save = function() {
         this.expire_days,
         this.cross_subdomain,
         this.secure,
+        this.cross_site,
         this.cookie_domain
     );
 };
@@ -282,6 +283,7 @@ MixpanelPersistence.prototype.update_config = function(config) {
     this.default_expiry = this.expire_days = config['cookie_expiration'];
     this.set_disabled(config['disable_persistence']);
     this.set_cookie_domain(config['cookie_domain']);
+    this.set_cross_site(config['cross_site_cookie']);
     this.set_cross_subdomain(config['cross_subdomain_cookie']);
     this.set_secure(config['secure_cookie']);
 };
@@ -299,6 +301,14 @@ MixpanelPersistence.prototype.set_cookie_domain = function(cookie_domain) {
     if (cookie_domain !== this.cookie_domain) {
         this.remove();
         this.cookie_domain = cookie_domain;
+        this.save();
+    }
+};
+
+MixpanelPersistence.prototype.set_cross_site = function(cross_site) {
+    if (cross_site !== this.cross_site) {
+        this.cross_site = cross_site;
+        this.remove();
         this.save();
     }
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1618,4 +1618,4 @@ _['info']['browser']        = _.info.browser;
 _['info']['browserVersion'] = _.info.browserVersion;
 _['info']['properties']     = _.info.properties;
 
-export { _, userAgent, console, win as window, document, navigator };
+export { _, userAgent, console, win as window, document, navigator, DOMAIN_MATCH_REGEX };

--- a/src/utils.js
+++ b/src/utils.js
@@ -985,14 +985,14 @@ _.cookie = {
         return cookie;
     },
 
-    set_seconds: function(name, value, seconds, cross_subdomain, is_secure, is_cross_site, domain_override) {
+    set_seconds: function(name, value, seconds, is_cross_subdomain, is_secure, is_cross_site, domain_override) {
         var cdomain = '',
             expires = '',
             secure = '';
 
         if (domain_override) {
             cdomain = '; domain=' + domain_override;
-        } else if (cross_subdomain) {
+        } else if (is_cross_subdomain) {
             var domain = extract_domain(document.location.hostname);
             cdomain = domain ? '; domain=.' + domain : '';
         }
@@ -1014,12 +1014,12 @@ _.cookie = {
         document.cookie = name + '=' + encodeURIComponent(value) + expires + '; path=/' + cdomain + secure;
     },
 
-    set: function(name, value, days, cross_subdomain, is_secure, is_cross_site, domain_override) {
+    set: function(name, value, days, is_cross_subdomain, is_secure, is_cross_site, domain_override) {
         var cdomain = '', expires = '', secure = '';
 
         if (domain_override) {
             cdomain = '; domain=' + domain_override;
-        } else if (cross_subdomain) {
+        } else if (is_cross_subdomain) {
             var domain = extract_domain(document.location.hostname);
             cdomain = domain ? '; domain=.' + domain : '';
         }
@@ -1043,8 +1043,8 @@ _.cookie = {
         return new_cookie_val;
     },
 
-    remove: function(name, cross_subdomain, domain_override) {
-        _.cookie.set(name, '', -1, cross_subdomain, false, false, domain_override);
+    remove: function(name, is_cross_subdomain, domain_override) {
+        _.cookie.set(name, '', -1, is_cross_subdomain, false, false, domain_override);
     }
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -44,8 +44,6 @@ var nativeBind = FuncProto.bind,
     nativeIsArray = Array.isArray,
     breaker = {};
 
-var DOMAIN_MATCH_REGEX = /[a-z0-9][a-z0-9-]+\.[a-z.]{2,6}$/i;
-
 var _ = {
     trim: function(str) {
         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim#Polyfill
@@ -993,10 +991,8 @@ _.cookie = {
             secure = '';
 
         if (cross_subdomain) {
-            var matches = document.location.hostname.match(DOMAIN_MATCH_REGEX),
-                domain = matches ? matches[0] : '';
-
-            cdomain = ((domain) ? '; domain=.' + domain : '');
+            var domain = extract_domain(document.location.hostname);
+            cdomain = domain ? '; domain=.' + domain : '';
         }
 
         if (seconds) {
@@ -1016,10 +1012,8 @@ _.cookie = {
         var cdomain = '', expires = '', secure = '';
 
         if (cross_subdomain) {
-            var matches = document.location.hostname.match(DOMAIN_MATCH_REGEX),
-                domain = matches ? matches[0] : '';
-
-            cdomain   = ((domain) ? '; domain=.' + domain : '');
+            var domain = extract_domain(document.location.hostname);
+            cdomain = domain ? '; domain=.' + domain : '';
         }
 
         if (days) {
@@ -1605,6 +1599,18 @@ _.info = {
     }
 };
 
+// naive way to extract domain name (example.com) from full hostname (my.sub.example.com)
+var SIMPLE_DOMAIN_MATCH_REGEX = /[a-z0-9][a-z0-9-]*\.[a-z]+$/i;
+// this next one attempts to account for some ccSLDs, e.g. extracting oxford.ac.uk from www.oxford.ac.uk
+// it's a pretty blunt heuristic and you can't do this reliably without a list like at https://publicsuffix.org/
+// but it maintains backwards compatibility with existing Mixpanel integrations
+var DOMAIN_MATCH_REGEX = /[a-z0-9][a-z0-9-]+\.[a-z.]{2,6}$/i;
+var extract_domain = function(hostname) {
+    var domain_regex = (hostname.endsWith('.com') || hostname.endsWith('.org')) ? SIMPLE_DOMAIN_MATCH_REGEX : DOMAIN_MATCH_REGEX;
+    var matches = hostname.match(domain_regex);
+    return matches ? matches[0] : '';
+};
+
 // EXPORTS (for closure compiler)
 _['toArray']                = _.toArray;
 _['isObject']               = _.isObject;
@@ -1618,4 +1624,4 @@ _['info']['browser']        = _.info.browser;
 _['info']['browserVersion'] = _.info.browserVersion;
 _['info']['properties']     = _.info.properties;
 
-export { _, userAgent, console, win as window, document, navigator, DOMAIN_MATCH_REGEX };
+export { _, userAgent, console, win as window, document, navigator, extract_domain };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1615,11 +1615,6 @@ _.info = {
 var SIMPLE_DOMAIN_MATCH_REGEX = /[a-z0-9][a-z0-9-]*\.[a-z]+$/i;
 // this next one attempts to account for some ccSLDs, e.g. extracting oxford.ac.uk from www.oxford.ac.uk
 var DOMAIN_MATCH_REGEX = /[a-z0-9][a-z0-9-]+\.[a-z.]{2,6}$/i;
-// does the hostname have a long TLD like .company?
-var has_long_tld = function(hostname) {
-    var parts = hostname.split('.');
-    return parts[parts.length - 1].length > 4;
-};
 /**
  * Attempts to extract main domain name from full hostname, using a few blunt heuristics. For
  * common TLDs like .com/.org that always have a simple SLD.TLD structure (example.com), we
@@ -1635,7 +1630,9 @@ var has_long_tld = function(hostname) {
  */
 var extract_domain = function(hostname) {
     var domain_regex = DOMAIN_MATCH_REGEX;
-    if (hostname.endsWith('.com') || hostname.endsWith('.org') || has_long_tld(hostname)) {
+    var parts = hostname.split('.');
+    var tld = parts[parts.length - 1];
+    if (tld.length > 4 || tld === 'com' || tld === 'org') {
         domain_regex = SIMPLE_DOMAIN_MATCH_REGEX;
     }
     var matches = hostname.match(domain_regex);

--- a/src/utils.js
+++ b/src/utils.js
@@ -985,7 +985,7 @@ _.cookie = {
         return cookie;
     },
 
-    set_seconds: function(name, value, seconds, cross_subdomain, is_secure, domain_override) {
+    set_seconds: function(name, value, seconds, cross_subdomain, is_secure, is_cross_site, domain_override) {
         var cdomain = '',
             expires = '',
             secure = '';
@@ -1003,14 +1003,18 @@ _.cookie = {
             expires = '; expires=' + date.toGMTString();
         }
 
+        if (is_cross_site) {
+            is_secure = true;
+            secure = '; SameSite=None';
+        }
         if (is_secure) {
-            secure = '; secure';
+            secure += '; secure';
         }
 
         document.cookie = name + '=' + encodeURIComponent(value) + expires + '; path=/' + cdomain + secure;
     },
 
-    set: function(name, value, days, cross_subdomain, is_secure, domain_override) {
+    set: function(name, value, days, cross_subdomain, is_secure, is_cross_site, domain_override) {
         var cdomain = '', expires = '', secure = '';
 
         if (domain_override) {
@@ -1026,8 +1030,12 @@ _.cookie = {
             expires = '; expires=' + date.toGMTString();
         }
 
+        if (is_cross_site) {
+            is_secure = true;
+            secure = '; SameSite=None';
+        }
         if (is_secure) {
-            secure = '; secure';
+            secure += '; secure';
         }
 
         var new_cookie_val = name + '=' + encodeURIComponent(value) + expires + '; path=/' + cdomain + secure;
@@ -1036,7 +1044,7 @@ _.cookie = {
     },
 
     remove: function(name, cross_subdomain, domain_override) {
-        _.cookie.set(name, '', -1, cross_subdomain, false, domain_override);
+        _.cookie.set(name, '', -1, cross_subdomain, false, false, domain_override);
     }
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1614,13 +1614,25 @@ _.info = {
 // naive way to extract domain name (example.com) from full hostname (my.sub.example.com)
 var SIMPLE_DOMAIN_MATCH_REGEX = /[a-z0-9][a-z0-9-]*\.[a-z]+$/i;
 // this next one attempts to account for some ccSLDs, e.g. extracting oxford.ac.uk from www.oxford.ac.uk
-// it's a pretty blunt heuristic and you can't do this reliably without a list like at https://publicsuffix.org/
-// but it maintains backwards compatibility with existing Mixpanel integrations
 var DOMAIN_MATCH_REGEX = /[a-z0-9][a-z0-9-]+\.[a-z.]{2,6}$/i;
+// does the hostname have a long TLD like .company?
 var has_long_tld = function(hostname) {
     var parts = hostname.split('.');
     return parts[parts.length - 1].length > 4;
 };
+/**
+ * Attempts to extract main domain name from full hostname, using a few blunt heuristics. For
+ * common TLDs like .com/.org that always have a simple SLD.TLD structure (example.com), we
+ * simply extract the last two .-separated parts of the hostname (SIMPLE_DOMAIN_MATCH_REGEX).
+ * For others, we attempt to account for short ccSLD+TLD combos (.ac.uk) with the legacy
+ * DOMAIN_MATCH_REGEX (kept to maintain backwards compatibility with existing Mixpanel
+ * integrations). The only _reliable_ way to extract domain from hostname is with an up-to-date
+ * list like at https://publicsuffix.org/ so for cases that this helper fails at, the SDK
+ * offers the 'cookie_domain' config option to set it explicitly.
+ * @example
+ * extract_domain('my.sub.example.com')
+ * // 'example.com'
+ */
 var extract_domain = function(hostname) {
     var domain_regex = DOMAIN_MATCH_REGEX;
     if (hostname.endsWith('.com') || hostname.endsWith('.org') || has_long_tld(hostname)) {

--- a/tests/test.js
+++ b/tests/test.js
@@ -703,6 +703,17 @@
                     clearLibInstance(mixpanel.cn2);
                 });
 
+                test("cross-site option doesn't break functionality", 2, function() {
+                    // we can only really test that setting cross_site_cookie works and
+                    // doesn't kill functionality, since you can't access cookie config
+                    // after setting it
+
+                    var cname = mixpanel.test.cookie.name;
+                    ok(cookie.exists(cname), "Cookie should exist");
+                    mixpanel.test.set_config({cross_site_cookie: true});
+                    ok(cookie.exists(cname), "Cookie should still exist");
+                });
+
                 test("cross subdomain", 4, function() {
                     var name = mixpanel.test.config.cookie_name;
 
@@ -722,7 +733,7 @@
 
                 if (document.location.hostname.split('.').length > 3) {
                     test("custom cookie domain", 1, function() {
-                        var cname = mixpanel.test.config.cookie_name;
+                        var cname = mixpanel.test.cookie.name;
                         var cdomain = document.location.hostname.split('.').slice(1).join('.');
                         mixpanel.test.set_config({cookie_domain: cdomain});
                         ok(cookie.exists(cname), "Cookie should still exist for current subdomain");

--- a/tests/test.js
+++ b/tests/test.js
@@ -720,6 +720,15 @@
                     ok(cookie.exists(name), "Cookie should still exist for current subdomain");
                 });
 
+                if (document.location.hostname.split('.').length > 3) {
+                    test("custom cookie domain", 1, function() {
+                        var cname = mixpanel.test.config.cookie_name;
+                        var cdomain = document.location.hostname.split('.').slice(1).join('.');
+                        mixpanel.test.set_config({cookie_domain: cdomain});
+                        ok(cookie.exists(cname), "Cookie should still exist for current subdomain");
+                    });
+                }
+
                 test("Old values loaded", 1, function() {
                     var c1 = {
                         distinct_id: '12345',

--- a/tests/unit/utils.js
+++ b/tests/unit/utils.js
@@ -18,4 +18,13 @@ describe(`DOMAIN_MATCH_REGEX`, function() {
   it(`supports many labels in a single hostname`, function() {
     expect(`my.sub.domain.mixpanel.com`.match(DOMAIN_MATCH_REGEX)[0]).to.equal(`mixpanel.com`);
   });
+
+  it(`supports a few common country code second-level domain names (ccSLD)`, function() {
+    expect(`www.oxford.ac.uk`.match(DOMAIN_MATCH_REGEX)[0]).to.equal(`oxford.ac.uk`);
+    expect(`www.dmv.ca.gov`.match(DOMAIN_MATCH_REGEX)[0]).to.equal(`dmv.ca.gov`);
+    expect(`www.imcc.isa.us`.match(DOMAIN_MATCH_REGEX)[0]).to.equal(`imcc.isa.us`);
+
+    // unfortunately can't do a real (sub)domain extraction without a list
+    // cases like www.avignon.aeroport.fr will still fail
+  });
 });

--- a/tests/unit/utils.js
+++ b/tests/unit/utils.js
@@ -1,30 +1,37 @@
 import { expect } from 'chai';
 
-import { DOMAIN_MATCH_REGEX } from '../../src/utils';
+import { extract_domain } from '../../src/utils';
 
-describe(`DOMAIN_MATCH_REGEX`, function() {
+describe(`extract_domain`, function() {
   it(`matches simple domain names`, function() {
-    expect(`mixpanel.com`.match(DOMAIN_MATCH_REGEX)[0]).to.equal(`mixpanel.com`);
-    expect(`abc.org`.match(DOMAIN_MATCH_REGEX)[0]).to.equal(`abc.org`);
-    expect(`superlongdomainnamepartfifteen.net`.match(DOMAIN_MATCH_REGEX)[0]).to.equal(`superlongdomainnamepartfifteen.net`);
-    expect(`startup.ly`.match(DOMAIN_MATCH_REGEX)[0]).to.equal(`startup.ly`);
+    expect(extract_domain(`mixpanel.com`)).to.equal(`mixpanel.com`);
+    expect(extract_domain(`abc.org`)).to.equal(`abc.org`);
+    expect(extract_domain(`superlongdomainnamepartfifteen.net`)).to.equal(`superlongdomainnamepartfifteen.net`);
+    expect(extract_domain(`startup.ly`)).to.equal(`startup.ly`);
   });
 
   it(`extracts domain names from hostnames with subdomains`, function() {
-    expect(`mysubdomain.mixpanel.com`.match(DOMAIN_MATCH_REGEX)[0]).to.equal(`mixpanel.com`);
-    expect(`superfly.startup.ly`.match(DOMAIN_MATCH_REGEX)[0]).to.equal(`startup.ly`);
+    expect(extract_domain(`mysubdomain.mixpanel.com`)).to.equal(`mixpanel.com`);
+    expect(extract_domain(`superfly.startup.ly`)).to.equal(`startup.ly`);
   });
 
   it(`supports many labels in a single hostname`, function() {
-    expect(`my.sub.domain.mixpanel.com`.match(DOMAIN_MATCH_REGEX)[0]).to.equal(`mixpanel.com`);
+    expect(extract_domain(`my.sub.domain.mixpanel.com`)).to.equal(`mixpanel.com`);
   });
 
   it(`supports a few common country code second-level domain names (ccSLD)`, function() {
-    expect(`www.oxford.ac.uk`.match(DOMAIN_MATCH_REGEX)[0]).to.equal(`oxford.ac.uk`);
-    expect(`www.dmv.ca.gov`.match(DOMAIN_MATCH_REGEX)[0]).to.equal(`dmv.ca.gov`);
-    expect(`www.imcc.isa.us`.match(DOMAIN_MATCH_REGEX)[0]).to.equal(`imcc.isa.us`);
+    expect(extract_domain(`www.oxford.ac.uk`)).to.equal(`oxford.ac.uk`);
+    expect(extract_domain(`www.dmv.ca.gov`)).to.equal(`dmv.ca.gov`);
+    expect(extract_domain(`www.imcc.isa.us`)).to.equal(`imcc.isa.us`);
 
     // unfortunately can't do a real (sub)domain extraction without a list
     // cases like www.avignon.aeroport.fr will still fail
+  });
+
+  it(`supports 2-char domain names in common TLDs`, function() {
+    expect(extract_domain(`my.com`)).to.equal(`my.com`);
+    expect(extract_domain(`subdomain.my.com`)).to.equal(`my.com`);
+    expect(extract_domain(`x.org`)).to.equal(`x.org`);
+    expect(extract_domain(`subdomain.x.org`)).to.equal(`x.org`);
   });
 });

--- a/tests/unit/utils.js
+++ b/tests/unit/utils.js
@@ -34,4 +34,9 @@ describe(`extract_domain`, function() {
     expect(extract_domain(`x.org`)).to.equal(`x.org`);
     expect(extract_domain(`subdomain.x.org`)).to.equal(`x.org`);
   });
+
+  it(`supports long TLDs`, function() {
+    expect(extract_domain(`supercool.company`)).to.equal(`supercool.company`);
+    expect(extract_domain(`sub.supercool.company`)).to.equal(`supercool.company`);
+  });
 });

--- a/tests/unit/utils.js
+++ b/tests/unit/utils.js
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+
+import { DOMAIN_MATCH_REGEX } from '../../src/utils';
+
+describe(`DOMAIN_MATCH_REGEX`, function() {
+  it(`matches simple domain names`, function() {
+    expect(`mixpanel.com`.match(DOMAIN_MATCH_REGEX)[0]).to.equal(`mixpanel.com`);
+    expect(`abc.org`.match(DOMAIN_MATCH_REGEX)[0]).to.equal(`abc.org`);
+    expect(`superlongdomainnamepartfifteen.net`.match(DOMAIN_MATCH_REGEX)[0]).to.equal(`superlongdomainnamepartfifteen.net`);
+    expect(`startup.ly`.match(DOMAIN_MATCH_REGEX)[0]).to.equal(`startup.ly`);
+  });
+
+  it(`extracts domain names from hostnames with subdomains`, function() {
+    expect(`mysubdomain.mixpanel.com`.match(DOMAIN_MATCH_REGEX)[0]).to.equal(`mixpanel.com`);
+    expect(`superfly.startup.ly`.match(DOMAIN_MATCH_REGEX)[0]).to.equal(`startup.ly`);
+  });
+
+  it(`supports many labels in a single hostname`, function() {
+    expect(`my.sub.domain.mixpanel.com`.match(DOMAIN_MATCH_REGEX)[0]).to.equal(`mixpanel.com`);
+  });
+});


### PR DESCRIPTION
- fixes very short .com/.org domains (e.g., ab.com)
- fixes long TLDs (e.g., foobar.company) (see https://github.com/mixpanel/mixpanel-js/pull/201)
- maintains backwards compatibility with existing integrations by auto-matching >2-part domains with short segments (e.g., www.oxford.ac.uk -> oxford.ac.uk)
- adds `cookie_domain` config option to provide complete control when the out-of-the-box heuristics don't come up with the right domain (the only way to be sure of getting the correct domain is with an extensive up-to-date list like https://publicsuffix.org/)
- adds `cross_site_cookie` config option to use `SameSite=None;Secure` for cases where the cookie domain is considered cross-site (e.g. embedded iframe from a different domain that initializes Mixpanel); fixes https://github.com/mixpanel/mixpanel-js/issues/243