### PR TITLE
fix: escape body of POST requests

### DIFF
--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -431,7 +431,7 @@ MixpanelLib.prototype._send_request = function(url, data, options, callback) {
     data['_'] = new Date().getTime().toString();
 
     if (use_post) {
-        body_data = 'data=' + data['data'];
+        body_data = 'data=' + encodeURIComponent(data['data']);
         delete data['data'];
     }
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -3680,6 +3680,25 @@
                     );
                 });
 
+                test("tracking should escape the body data of POST request", 5, function() {
+                    // this body tends to generate the characters + and = when using encode_data_for_request
+                    mixpanel.test.track('test', {title: 'Opatření na zadržení vody v krajině'});
+
+                    same(this.requests.length, 1, "track should have fired off a request");
+
+                    var req = this.requests[0];
+                    same(req.method, 'POST');
+                    var bodyData = req.requestBody.replace('data=', '');
+                    var badCharacters = ['+', '/', '='];
+                    for (var i = 0; i < badCharacters.length; i += 1) {
+                        var badCharacter = badCharacters[i];
+                        same(
+                            bodyData.indexOf(badCharacter), -1,
+                            'POST request body has invalid character ' + badCharacter
+                        );
+                    }
+                });
+
                 test("tracking can be configured to GET", 4, function() {
                     mixpanel.test.set_config({api_method: 'GET'});
 
@@ -4260,7 +4279,7 @@
                         });
 
                         // test cases using browser DoNotTrack (DNT) setting
-                        
+
                         // standard case: navigator.doNotTrack="1" but ignore_dnt=true
                         gdprTest(method + ' tracking is enabled due to ignore_dnt even with the browser DoNotTrack setting (navigator.doNotTrack="1")', {
                             opt_in: true,


### PR DESCRIPTION
According to [the spec](https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.1) for requests of type `application/x-www-form-urlencoded`, the body must be escaped. Currently the data is encoded to base64, so it will usually be alphanumeric, but has the chance of producing `+`, `/`, or `=` characters.

It appears the Mixpanel API is already equipped to handle both the escaped and unescaped base64 requests, but proxies or intercepting APIs would need to implement special rules to handle this.