### PR TITLE
add opt-out logging in debug mode

### DIFF
--- a/src/gdpr-utils.js
+++ b/src/gdpr-utils.js
@@ -11,7 +11,7 @@
  * These functions are used internally by the SDK and are not intended to be publicly exposed.
  */
 
-import { _, window } from './utils';
+import { _, console, window } from './utils';
 
 /**
  * A function used to track a Mixpanel event (e.g. MixpanelLib.track)
@@ -83,12 +83,12 @@ export function hasOptedIn(token, options) {
  */
 export function hasOptedOut(token, options) {
     if (_hasDoNotTrackFlagOn(options)) {
-        console.warn('[Mixpanel SDK] This browser has "Do Not Track" enabled. This will prevent the Mixpanel SDK from sending any data. To ignore the "Do Not Track" browser setting, initialize the Mixpanel instance with the config "ignore_dnt: true"');
+        console.warn('This browser has "Do Not Track" enabled. This will prevent the Mixpanel SDK from sending any data. To ignore the "Do Not Track" browser setting, initialize the Mixpanel instance with the config "ignore_dnt: true"');
         return true;
     }
     var optedOut = _getStorageValue(token, options) === '0';
     if (optedOut) {
-        console.warn('[Mixpanel SDK] You are opted out of Mixpanel tracking. This will prevent the Mixpanel SDK from sending any data.');
+        console.warn('You are opted out of Mixpanel tracking. This will prevent the Mixpanel SDK from sending any data.');
     }
     return optedOut;
 }

--- a/src/gdpr-utils.js
+++ b/src/gdpr-utils.js
@@ -79,19 +79,16 @@ export function hasOptedIn(token, options) {
  * @param {string} [options.persistenceType] Persistence mechanism used - cookie or localStorage
  * @param {string} [options.persistencePrefix=__mp_opt_in_out] - custom prefix to be used in the cookie/localstorage name
  * @param {boolean} [options.ignoreDnt] - flag to ignore browser DNT settings and always return false
- * @param {boolean} [options.debug] - flag to show debug statements
  * @returns {boolean} whether the user has opted out of the given opt type
  */
 export function hasOptedOut(token, options) {
     if (_hasDoNotTrackFlagOn(options)) {
-        if (options.debug) {
-            console.warn('[Mixpanel SDK] This browser has "Do Not Track" enabled. This will prevent the Mixpanel SDK from sending any data. To ignore the "Do Not Track" browser setting, initialize the Mixpanel instance with the config "ignore_dnt: true"');
-        }
+        console.warn('[Mixpanel SDK] This browser has "Do Not Track" enabled. This will prevent the Mixpanel SDK from sending any data. To ignore the "Do Not Track" browser setting, initialize the Mixpanel instance with the config "ignore_dnt: true"');
         return true;
     }
     var optedOut = _getStorageValue(token, options) === '0';
-    if (optedOut && options.debug) {
-        console.warn('[Mixpanel SDK] You have opted out of Mixpanel tracking. This will prevent the Mixpanel SDK from sending any data.');
+    if (optedOut) {
+        console.warn('[Mixpanel SDK] You are opted out of Mixpanel tracking. This will prevent the Mixpanel SDK from sending any data.');
     }
     return optedOut;
 }
@@ -275,7 +272,6 @@ function _addOptOutCheck(method, getConfigValue) {
             var ignoreDnt = getConfigValue.call(this, 'ignore_dnt');
             var persistenceType = getConfigValue.call(this, 'opt_out_tracking_persistence_type');
             var persistencePrefix = getConfigValue.call(this, 'opt_out_tracking_cookie_prefix');
-            var debug = getConfigValue.call(this, 'debug');
             var win = getConfigValue.call(this, 'window'); // used to override window during browser tests
 
             if (token) { // if there was an issue getting the token, continue method execution as normal
@@ -283,7 +279,6 @@ function _addOptOutCheck(method, getConfigValue) {
                     ignoreDnt: ignoreDnt,
                     persistenceType: persistenceType,
                     persistencePrefix: persistencePrefix,
-                    debug: debug,
                     window: win
                 });
             }

--- a/src/gdpr-utils.js
+++ b/src/gdpr-utils.js
@@ -79,13 +79,21 @@ export function hasOptedIn(token, options) {
  * @param {string} [options.persistenceType] Persistence mechanism used - cookie or localStorage
  * @param {string} [options.persistencePrefix=__mp_opt_in_out] - custom prefix to be used in the cookie/localstorage name
  * @param {boolean} [options.ignoreDnt] - flag to ignore browser DNT settings and always return false
+ * @param {boolean} [options.debug] - flag to show debug statements
  * @returns {boolean} whether the user has opted out of the given opt type
  */
 export function hasOptedOut(token, options) {
     if (_hasDoNotTrackFlagOn(options)) {
+        if (options.debug) {
+            console.warn('[Mixpanel SDK] This browser has "Do Not Track" enabled. This will prevent the Mixpanel SDK from sending any data. To ignore the "Do Not Track" browser setting, initialize the Mixpanel instance with the config "ignore_dnt: true"');
+        }
         return true;
     }
-    return _getStorageValue(token, options) === '0';
+    var optedOut = _getStorageValue(token, options) === '0';
+    if (optedOut && options.debug) {
+        console.warn('[Mixpanel SDK] You have opted out of Mixpanel tracking. This will prevent the Mixpanel SDK from sending any data.');
+    }
+    return optedOut;
 }
 
 /**
@@ -267,6 +275,7 @@ function _addOptOutCheck(method, getConfigValue) {
             var ignoreDnt = getConfigValue.call(this, 'ignore_dnt');
             var persistenceType = getConfigValue.call(this, 'opt_out_tracking_persistence_type');
             var persistencePrefix = getConfigValue.call(this, 'opt_out_tracking_cookie_prefix');
+            var debug = getConfigValue.call(this, 'debug');
             var win = getConfigValue.call(this, 'window'); // used to override window during browser tests
 
             if (token) { // if there was an issue getting the token, continue method execution as normal
@@ -274,6 +283,7 @@ function _addOptOutCheck(method, getConfigValue) {
                     ignoreDnt: ignoreDnt,
                     persistenceType: persistenceType,
                     persistencePrefix: persistencePrefix,
+                    debug: debug,
                     window: win
                 });
             }

--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -1724,7 +1724,8 @@ MixpanelLib.prototype._gdpr_call_func = function(func, options) {
         'cross_subdomain_cookie': this.get_config('cross_subdomain_cookie'),
         'cookie_domain': this.get_config('cookie_domain'),
         'secure_cookie': this.get_config('secure_cookie'),
-        'ignore_dnt': this.get_config('ignore_dnt')
+        'ignore_dnt': this.get_config('ignore_dnt'),
+        'debug': this.get_config('debug')
     }, options);
 
     // check if localStorage can be used for recording opt out status, fall back to cookie if not
@@ -1743,7 +1744,8 @@ MixpanelLib.prototype._gdpr_call_func = function(func, options) {
         crossSiteCookie: options['cross_site_cookie'],
         crossSubdomainCookie: options['cross_subdomain_cookie'],
         secureCookie: options['secure_cookie'],
-        ignoreDnt: options['ignore_dnt']
+        ignoreDnt: options['ignore_dnt'],
+        debug: options['debug']
     });
 };
 

--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -1724,8 +1724,7 @@ MixpanelLib.prototype._gdpr_call_func = function(func, options) {
         'cross_subdomain_cookie': this.get_config('cross_subdomain_cookie'),
         'cookie_domain': this.get_config('cookie_domain'),
         'secure_cookie': this.get_config('secure_cookie'),
-        'ignore_dnt': this.get_config('ignore_dnt'),
-        'debug': this.get_config('debug')
+        'ignore_dnt': this.get_config('ignore_dnt')
     }, options);
 
     // check if localStorage can be used for recording opt out status, fall back to cookie if not
@@ -1744,8 +1743,7 @@ MixpanelLib.prototype._gdpr_call_func = function(func, options) {
         crossSiteCookie: options['cross_site_cookie'],
         crossSubdomainCookie: options['cross_subdomain_cookie'],
         secureCookie: options['secure_cookie'],
-        ignoreDnt: options['ignore_dnt'],
-        debug: options['debug']
+        ignoreDnt: options['ignore_dnt']
     });
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -67,6 +67,19 @@ var console = {
         }
     },
     /** @type {function(...*)} */
+    warn: function() {
+        if (Config.DEBUG && !_.isUndefined(windowConsole) && windowConsole) {
+            var args = ['Mixpanel warning:'].concat(_.toArray(arguments));
+            try {
+                windowConsole.warn.apply(windowConsole, args);
+            } catch (err) {
+                _.each(args, function(arg) {
+                    windowConsole.warn(arg);
+                });
+            }
+        }
+    },
+    /** @type {function(...*)} */
     error: function() {
         if (Config.DEBUG && !_.isUndefined(windowConsole) && windowConsole) {
             var args = ['Mixpanel error:'].concat(_.toArray(arguments));


### PR DESCRIPTION
It's difficult to debug why events aren't being sent when a user is opted out (particularly in the "Do Not Track" case). This adds some logging for these cases when the library is initialized in debug mode.