### PR TITLE
Doc improvements

### DIFF
--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -758,7 +758,7 @@ MixpanelLib.prototype._track_or_batch = function(options, callback) {
  *
  * @param {String} event_name The name of the event. This can be anything the user does - 'Button Click', 'Sign Up', 'Item Purchased', etc.
  * @param {Object} [properties] A set of properties to include with the event you're sending. These describe the user who did the event or details about the event itself.
- * @param {Object} [options] Optional configuration for this track request.
+ * @param {Object} [options] Optional configuration for this track request; valid options are 'transport' and/or 'send_immediately'
  * @param {String} [options.transport] Transport method for network request ('xhr' or 'sendBeacon').
  * @param {Boolean} [options.send_immediately] Whether to bypass batching/queueing and send track request immediately.
  * @param {Function} [callback] If provided, the callback function will be called after tracking the event.

--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -195,7 +195,7 @@ var create_mplib = function(token, config, name) {
  *     mixpanel.library_name.track(...);
  *
  * @param {String} token   Your Mixpanel API token
- * @param {Object} [config]  A dictionary of config options to override. <a href="https://github.com/mixpanel/mixpanel-js/blob/8b2e1f7b/src/mixpanel-core.js#L87-L110">See a list of default config options</a>.
+ * @param {Object} [config]  A dictionary of config options to override. <a href="https://github.com/mixpanel/mixpanel-js/blob/master/src/mixpanel-core.js#L86-L127">See a list of default config options</a>.
  * @param {String} [name]    The name for the new mixpanel instance that you want created
  */
 MixpanelLib.prototype.init = function (token, config, name) {

--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -758,7 +758,7 @@ MixpanelLib.prototype._track_or_batch = function(options, callback) {
  *
  * @param {String} event_name The name of the event. This can be anything the user does - 'Button Click', 'Sign Up', 'Item Purchased', etc.
  * @param {Object} [properties] A set of properties to include with the event you're sending. These describe the user who did the event or details about the event itself.
- * @param {Object} [options] Optional configuration for this track request; valid options are 'transport' and/or 'send_immediately'
+ * @param {Object} [options] Optional configuration for this track request.
  * @param {String} [options.transport] Transport method for network request ('xhr' or 'sendBeacon').
  * @param {Boolean} [options.send_immediately] Whether to bypass batching/queueing and send track request immediately.
  * @param {Function} [callback] If provided, the callback function will be called after tracking the event.

--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -195,7 +195,7 @@ var create_mplib = function(token, config, name) {
  *     mixpanel.library_name.track(...);
  *
  * @param {String} token   Your Mixpanel API token
- * @param {Object} [config]  A dictionary of config options to override. <a href="https://github.com/mixpanel/mixpanel-js/blob/master/src/mixpanel-core.js#L86-L127">See a list of default config options</a>.
+ * @param {Object} [config]  A dictionary of config options to override. <a href="https://github.com/mixpanel/mixpanel-js/blob/3e9cf45/src/mixpanel-core.js#L86-L127">See a list of default config options</a>.
  * @param {String} [name]    The name for the new mixpanel instance that you want created
  */
 MixpanelLib.prototype.init = function (token, config, name) {


### PR DESCRIPTION
two small improvements on the docs:

- clear language on possible `.track()` configurations
- link to most current default config