### PR TITLE
Use monotonic clock for time based entropy

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -831,10 +831,10 @@ _.utf8Encode = function(string) {
 _.UUID = (function() {
 
     // Time-based entropy
-    var T = () => {
+    var T = function() => {
         var time = Date.now();
         var performance = window.performance.now();
-        return `${time.toString(16)}-${Math.floor(performance).toString(16)}`;
+        return time.toString(16) + Math.floor(performance).toString(16);
     };
 
     // Math.Random entropy

--- a/src/utils.js
+++ b/src/utils.js
@@ -830,20 +830,11 @@ _.utf8Encode = function(string) {
 
 _.UUID = (function() {
 
-    // Time/ticks information
-    // 1*new Date() is a cross browser version of Date.now()
-    var T = function() {
-        var d = 1 * new Date(),
-            i = 0;
-
-        // this while loop figures how many browser ticks go by
-        // before 1*new Date() returns a new number, ie the amount
-        // of ticks that go by per millisecond
-        while (d == 1 * new Date()) {
-            i++;
-        }
-
-        return d.toString(16) + i.toString(16);
+    // Time-based entropy
+    var T = () => {
+        var time = Date.now();
+        var performance = window.performance.now();
+        return `${time.toString(16)}-${Math.floor(performance).toString(16)}`;
     };
 
     // Math.Random entropy

--- a/src/utils.js
+++ b/src/utils.js
@@ -831,7 +831,7 @@ _.utf8Encode = function(string) {
 _.UUID = (function() {
 
     // Time-based entropy
-    var T = function() => {
+    var T = function() {
         var time = Date.now();
         var performance = window.performance.now();
         return time.toString(16) + Math.floor(performance).toString(16);


### PR DESCRIPTION
**Preface:**
The uuid generates time entropy using the number of increments between a milisecond that the client computer can complete. 

**The problem:** 
Is that any mocking of the Date() object that returns a constant value will cause an endless loop of never ending increments. Specifically, when Date.valueOf() returns a constant number (IE `Date.valueOf = () => 123`). This means that any mocking of Date before mixpanel.init() is not possible which breaks any proper clock mocking in cypress and possibly other testing frameworks mocking time.

**How to reproduce:**
Setup up a cypress spec file that test your localhost. Set up with a localhost repo that successfully calls mixpanel.init() at any point.
```ts
describe('Cypress clock issue', () => {
  it('mixpanel infinite uuid loop', () => {
     cy.clock();
     cy.visit('/')
     // this will cause the browser to stall and maybe crash from the infinite loop     
   })
})
```

**Possible Solution:**
Switch the implementation to use the monotonic clock available within the browser. The monotonic clock can't be edited by the client and would be a good use case for this situation since time is used as a measure of time entropy and not for time itself.

Issue: #367 