### PR TITLE
Add marketing parameters to event when track_marketing set

### DIFF
--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -99,6 +99,7 @@ var DEFAULT_CONFIG = {
     'cookie_domain':                     '',
     'cookie_name':                       '',
     'loaded':                            NOOP_FUNC,
+    'track_marketing':                   false,
     'store_google':                      true,
     'save_referrer':                     true,
     'test':                              false,
@@ -804,6 +805,10 @@ MixpanelLib.prototype.track = addOptOutCheckMixpanelLib(function(event_name, pro
 
     this._set_default_superprops();
 
+    var marketing_properties = this.get_config('track_marketing')
+        ? _.info.marketingParams()
+        : {};
+
     // note: extend writes to the first object, so lets make sure we
     // don't write to the persistence properties object and info
     // properties object by passing in a new object
@@ -814,6 +819,7 @@ MixpanelLib.prototype.track = addOptOutCheckMixpanelLib(function(event_name, pro
         _.info.properties(),
         this['persistence'].properties(),
         this.unpersisted_superprops,
+        marketing_properties,
         properties
     );
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1425,6 +1425,24 @@ _.info = {
         return params;
     },
 
+    clickParams: function() {
+        var click_ids = ['dclid', 'fbclid', 'gclid', 'ko_click_id', 'li_fat_id', 'msclkid', 'ttclid', 'twclid', 'wbraid'],
+            id = '',
+            params = {};
+        _.each(click_ids, function(idkey) {
+            id = _.getQueryParam(document.URL, idkey);
+            if (id.length) {
+                params[idkey] = id;
+            }
+        });
+
+        return params;
+    },
+
+    marketingParams: function() {
+        return _.extend(_.info.campaignParams(), _.info.clickParams());
+    },
+
     searchEngine: function(referrer) {
         if (referrer.search('https?://(.*)google.([^/?]*)') === 0) {
             return 'google';


### PR DESCRIPTION
## Description
We're interested in tracking some additional marketing data with a new `track_marketing` option. Additionally, events should have the marketing parameters appended if and only if they're present in the current URL. This means no persistence of any kind, even for the current page load or instance of the SDK.