### PR TITLE
Set first touch UTM params on profiles at the end of initialization

### DIFF
--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -101,6 +101,7 @@ var DEFAULT_CONFIG = {
     'loaded':                            NOOP_FUNC,
     'store_google':                      true,
     'save_referrer':                     true,
+    'skip_first_touch_marketing':        false,
     'test':                              false,
     'verbose':                           false,
     'img':                               false,
@@ -308,6 +309,25 @@ MixpanelLib.prototype._init = function(token, config, name) {
             'distinct_id': DEVICE_ID_PREFIX + uuid,
             '$device_id': uuid
         }, '');
+    }
+
+    if (!this.get_config('skip_first_touch_marketing')) {
+        // We need null UTM params in the object because
+        // UTM parameters act as a tuple. If any UTM param
+        // is present, then we set all UTM params including
+        // empty ones together
+        var utm_params = _.info.campaignParams(null);
+        var initial_utm_params = {};
+        var has_utm = false;
+        _.each(utm_params, function(utm_value, utm_key) {
+            initial_utm_params['initial_' + utm_key] = utm_value;
+            if (utm_value) {
+                has_utm = true;
+            }
+        });
+        if (has_utm) {
+            this['people'].set_once(initial_utm_params);
+        }
     }
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1411,7 +1411,7 @@ _.dom_query = (function() {
 })();
 
 _.info = {
-    campaignParams: function() {
+    campaignParams: function(default_value) {
         var campaign_keywords = 'utm_source utm_medium utm_campaign utm_content utm_term'.split(' '),
             kw = '',
             params = {};
@@ -1419,6 +1419,8 @@ _.info = {
             kw = _.getQueryParam(document.URL, kwkey);
             if (kw.length) {
                 params[kwkey] = kw;
+            } else if (default_value !== undefined) {
+                params[kwkey] = default_value;
             }
         });
 


### PR DESCRIPTION
## Description
We want to enrich user profiles with first touch marketing data. This change only includes UTM parameters, but we also want to consider click IDs. The changes include an option to disable this functionality.

A couple of thoughts:
- Is the end of _init generally the right place to ensure this is executed correctly?
- I make an assumption here that setting a user profile property with `null` means it won't be written over with additional set_once calls that may have a non-empty value. Is that true?