### PR TITLE
Accept 204 No Content as a valid success status

### DIFF
--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -516,7 +516,7 @@ MixpanelLib.prototype._send_request = function(url, data, options, callback) {
             req.withCredentials = true;
             req.onreadystatechange = function () {
                 if (req.readyState === 4) { // XMLHttpRequest.DONE == 4, except in safari 4
-                    if (req.status === 200) {
+                    if (req.status === 200 || req.status === 204) {
                         if (callback) {
                             if (verbose_mode) {
                                 var response;


### PR DESCRIPTION
Hey! Small (and first) contribution to the project.

When proxying requests through a backend, the backend might return 204 No Content to indicate the request was processed but there's nothing to return. Consider this response successful.

As it is my first contribution, I wasn't sure if any other files needed to be modified. I'd be happy to tweak the PR with guidance if something else is needed. 

Thanks for considering!