### PR TITLE
Ignore AhrefsSiteAudit Crawler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tunnel.log
 *.swp
 *.ps1
 *.bundle.js
+.DS_Store

--- a/src/utils.js
+++ b/src/utils.js
@@ -899,6 +899,7 @@ _.UUID = (function() {
 // sending false tracking data
 var BLOCKED_UA_STRS = [
     'ahrefsbot',
+    'ahrefssiteaudit',
     'baiduspider',
     'bingbot',
     'bingpreview',

--- a/tests/test.js
+++ b/tests/test.js
@@ -3460,6 +3460,8 @@
                 var bot_user_agents = [
                     "Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)",
                     "Mozilla/5.0 (compatible; AhrefsBot/7.0; +http://ahrefs.com/robot/)",
+                    "Mozilla/5.0 (compatible; AhrefsSiteAudit/6.1; +http://ahrefs.com/robot/site-audit)", // Desktop
+                    "Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.5359.128 Mobile Safari/537.36 (compatible; AhrefsSiteAudit/6.1; +http://ahrefs.com/robot/site-audit)", // Mobile
                     "Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)",
                     "Mozilla/5.0 (Windows Phone 8.1; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 530) like Gecko (compatible; adidxbot/2.0; +http://www.bing.com/bingbot.htm)",
                     "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/534+ (KHTML, like Gecko) BingPreview/1.0b",

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -23,7 +23,7 @@
                 <path d="M21.314,18.261H1c-0.552,0-1-0.448-1-1s0.448-1,1-1h20.314c0.552,0,1,0.448,1,1S21.867,18.261,21.314,18.261z"></path>
             </svg>
         </div>
-        <script>window.MIXPANEL_CUSTOM_LIB_URL = '../build/mixpanel.js';</script>
+        <script>window.MIXPANEL_CUSTOM_LIB_URL = '../mixpanel.js';</script>
         <script type="text/javascript" src="redirect-unless-referrer.js"></script>
         <script type="text/javascript" src="../mixpanel-jslib-snippet.js"></script>
         <script type="text/javascript" src="./run-tests.js"></script>


### PR DESCRIPTION
Ahrefs has a [bot](https://ahrefs.com/robot) as well as a [site audit](https://ahrefs.com/robot/site-audit). We had previously just blocked the bot but now we also block the audit.

Also fix integrations tests.html