### PR TITLE
Remove Date.now polyfill (fixes #448)

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -339,9 +339,6 @@ _.encodeDates = function(obj) {
 };
 
 _.timestamp = function() {
-    Date.now = Date.now || function() {
-        return +new Date;
-    };
     return Date.now();
 };
 


### PR DESCRIPTION
Remove polyfill for `Date.now` method in `utils.js`. The method has wide browser support (IE starting with v9).