### PR TITLE
feat: supports passing arbitrary query parameters on send requests

### DIFF
--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -98,6 +98,7 @@ var DEFAULT_API_ROUTES = {
 var DEFAULT_CONFIG = {
     'api_host':                          'https://api-js.mixpanel.com',
     'api_routes':                        DEFAULT_API_ROUTES,
+    'api_additional_query_params':       '',
     'api_method':                        'POST',
     'api_transport':                     'XHR',
     'api_payload_format':                PAYLOAD_TYPE_BASE64,
@@ -628,6 +629,7 @@ MixpanelLib.prototype._send_request = function(url, data, options, callback) {
 
     var DEFAULT_OPTIONS = {
         method: this.get_config('api_method'),
+        additional_query_params: this.get_config('api_additional_query_params'),
         transport: this.get_config('api_transport'),
         verbose: this.get_config('verbose')
     };
@@ -672,6 +674,10 @@ MixpanelLib.prototype._send_request = function(url, data, options, callback) {
     }
 
     url += '?' + _.HTTPBuildQuery(data);
+
+    if (options.additional_query_params) {
+        url += '&' + options.additional_query_params;
+    }
 
     var lib = this;
     if ('img' in data) {

--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -673,7 +673,7 @@ MixpanelLib.prototype._send_request = function(url, data, options, callback) {
     }
 
     _.extend(data, this.get_config('api_extra_query_params'));
-    
+
     url += '?' + _.HTTPBuildQuery(data);
 
     var lib = this;

--- a/src/mixpanel-core.js
+++ b/src/mixpanel-core.js
@@ -98,7 +98,7 @@ var DEFAULT_API_ROUTES = {
 var DEFAULT_CONFIG = {
     'api_host':                          'https://api-js.mixpanel.com',
     'api_routes':                        DEFAULT_API_ROUTES,
-    'api_additional_query_params':       '',
+    'api_extra_query_params':            {},
     'api_method':                        'POST',
     'api_transport':                     'XHR',
     'api_payload_format':                PAYLOAD_TYPE_BASE64,
@@ -629,7 +629,6 @@ MixpanelLib.prototype._send_request = function(url, data, options, callback) {
 
     var DEFAULT_OPTIONS = {
         method: this.get_config('api_method'),
-        additional_query_params: this.get_config('api_additional_query_params'),
         transport: this.get_config('api_transport'),
         verbose: this.get_config('verbose')
     };
@@ -673,11 +672,9 @@ MixpanelLib.prototype._send_request = function(url, data, options, callback) {
         delete data['data'];
     }
 
+    _.extend(data, this.get_config('api_extra_query_params'));
+    
     url += '?' + _.HTTPBuildQuery(data);
-
-    if (options.additional_query_params) {
-        url += '&' + options.additional_query_params;
-    }
 
     var lib = this;
     if ('img' in data) {

--- a/tests/test.js
+++ b/tests/test.js
@@ -500,13 +500,13 @@
         test("additional query string is honored", 1, function() {
             mixpanel.test.set_config({
                 img: true,
-                api_additional_query_params: 'some_param=some_value&another_param=another_value'
+                api_extra_query_params: {some_param: 'some_value', another_param: 'another_value'}
             });
 
-            mixpanel.test.track("api_additional_query_params set");
+            mixpanel.test.track("api_extra_query_params set");
             var with_additional_query_params = $('img').get(-1);
 
-            ok(with_additional_query_params.src.indexOf('some_param=some_value&another_param=another_value') > 0, '_send_request should send api_additional_query_params when configured');
+            ok(with_additional_query_params.src.indexOf('some_param=some_value&another_param=another_value') > 0, '_send_request should send extra_query_params when configured');
         });
 
         test("properties on blacklist are not sent", 4, function() {

--- a/tests/test.js
+++ b/tests/test.js
@@ -497,15 +497,16 @@
         });
 
 
-        test("additional query string is honored", 2, function() {
+        test("additional query string is honored", 1, function() {
             mixpanel.test.set_config({
+                img: true,
                 api_additional_query_params: 'some_param=some_value&another_param=another_value'
             });
 
             mixpanel.test.track("api_additional_query_params set");
             var with_additional_query_params = $('img').get(-1);
 
-            ok(with_additional_query_params.src.indexOf('some_param=some_value&another_param=another_value') > 0, '_send_request should send ip=1 by default');
+            ok(with_additional_query_params.src.indexOf('some_param=some_value&another_param=another_value') > 0, '_send_request should send api_additional_query_params when configured');
         });
 
         test("properties on blacklist are not sent", 4, function() {

--- a/tests/test.js
+++ b/tests/test.js
@@ -496,6 +496,18 @@
             ok(without_ip.src.indexOf('ip=0') > 0, '_send_request should send ip=0 when the config ip=false');
         });
 
+
+        test("additional query string is honored", 2, function() {
+            mixpanel.test.set_config({
+                api_additional_query_params: 'some_param=some_value&another_param=another_value'
+            });
+
+            mixpanel.test.track("api_additional_query_params set");
+            var with_additional_query_params = $('img').get(-1);
+
+            ok(with_additional_query_params.src.indexOf('some_param=some_value&another_param=another_value') > 0, '_send_request should send ip=1 by default');
+        });
+
         test("properties on blacklist are not sent", 4, function() {
             mixpanel.test.set_config({
                 property_blacklist: ['$current_url', '$referrer', 'blacklisted_custom_prop']


### PR DESCRIPTION
## Purpose

closes #477.  

## Approach

Allows setting new configuration `api_extra_query_params`. If this is set, then anything contained is appended to the query string as part of the call to `HTTPBuildQuery` when building the url to make a tracking request to. 


