### PR TITLE
Create dependabot yml, ignore findings from examples on future scans

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# .github/dependabot.yml
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/" # Location of package.json files
+    schedule:
+      interval: "daily"
+    # Ignore dependencies found within pattern-matched directories
+    ignore:
+      - dependency-name: "*" # Apply to all dependencies
+        patterns:
+          - "examples/*"     # Ignore any package.json or lock file within 'examples/'


### PR DESCRIPTION
We are ignoring the examples directory. This directory is solely for demonstrating SDK implementation and is neither maintained nor integrated into the application build process.