### PR TITLE
feat: add missing record_heatmap_data property to Config type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -184,6 +184,7 @@ export interface Config {
   record_max_ms: number;
   record_sessions_percent: number;
   record_canvas: boolean;
+  record_heatmap_data: boolean;
 }
 
 export type VerboseResponse =


### PR DESCRIPTION
## Description
This PR adds the missing `record_heatmap_data` property to the `Config` type definition.
issue: #499 

## Problem
The `record_heatmap_data` property is supported by the Mixpanel JavaScript SDK but is missing from the TypeScript type definitions, causing TypeScript compilation errors when trying to use this feature.

## Error Before Fix
```typescript
mixpanel.init(token, {
  record_heatmap_data: true // TypeScript Error: Property 'record_heatmap_data' does not exist on type 'Partial<Config>'
})
```
