### PR TITLE
Add missing Typescript fields

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -125,6 +125,8 @@ export interface Config {
     track?: string;
     engage?: string;
     groups?: string;
+    record?: string;
+    flags?: string;
   };
   api_method: string;
   api_transport: string;


### PR DESCRIPTION
Add missing `record` and `flags` fields to `api_routes`