### PR TITLE
fix: add typings for alternative entrypoints

### DIFF
--- a/dist/mixpanel-core.cjs.d.ts
+++ b/dist/mixpanel-core.cjs.d.ts
@@ -1,0 +1,1 @@
+export * from '../src/index';

--- a/dist/mixpanel-with-async-recorder.cjs.d.ts
+++ b/dist/mixpanel-with-async-recorder.cjs.d.ts
@@ -1,0 +1,1 @@
+export * from '../src/index';

--- a/src/loaders/loader-module-core.d.ts
+++ b/src/loaders/loader-module-core.d.ts
@@ -1,0 +1,1 @@
+export * from '../index';

--- a/src/loaders/loader-module-with-async-recorder.d.ts
+++ b/src/loaders/loader-module-with-async-recorder.d.ts
@@ -1,0 +1,1 @@
+export * from '../index';


### PR DESCRIPTION
These were present in `@types/mixpanel-browser` before but got lost when inlining them. I originally introduced them in the external types through https://github.com/DefinitelyTyped/DefinitelyTyped/pull/72165.

Fixes #501