### PR TITLE
feat: add missing `record_min_ms` property to `Config` type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -199,6 +199,7 @@ export interface Config {
   record_mask_text_class: string;
   record_mask_text_selector: string;
   record_max_ms: number;
+  record_min_ms: number;
   record_sessions_percent: number;
   record_canvas: boolean;
   record_heatmap_data: boolean;


### PR DESCRIPTION
This PR adds a missing property `record_min_ms` to configuration type (#508 ).  