### PR TITLE
Fix exports to solve type errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,11 @@
   },
   "types": "./src/index.d.ts",
   "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "import": "./dist/mixpanel.module.js",
+      "require": "./dist/mixpanel.cjs.js"
+    },
     "./src/loaders/loader-module-core": {
       "types": "./src/index.d.ts",
       "import": "./src/loaders/loader-module-core.js",


### PR DESCRIPTION
The dts doesn't work (`Cannot find module 'mixpanel-browser' or its corresponding type declarations.`) in my Vue project without this.