### PR TITLE
Fix TypeScript defs: allow string | RegExp for record_block_class and record_mask_text_class

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -191,12 +191,12 @@ export interface Config {
   batch_size: number;
   batch_flush_interval_ms: number;
   batch_request_timeout_ms: number;
-  record_block_class: string;
+  record_block_class: string | RegExp;
   record_block_selector: string;
   record_collect_fonts: boolean;
   record_idle_timeout_ms: number;
   record_inline_images: boolean;
-  record_mask_text_class: string;
+  record_mask_text_class: string | RegExp;
   record_mask_text_selector: string;
   record_min_ms: number;
   record_max_ms: number;


### PR DESCRIPTION
This PR updates the TypeScript type definitions for session recording
options:

- `record_block_class?: string | RegExp`
- `record_mask_text_class?: string | RegExp`

Background:
- Defaults in `mixpanel-core.js` are regexes, so runtime already supports
  RegExp.
- Documentation states both string and regex are valid.
- Current defs only allow `string`, forcing TS users to use `any` or
  declaration merging.

Fix:
- Updated `src/index.d.ts` to accept `string | RegExp`.

Closes #521