### PR TITLE
Add `flags` type to Config interface

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -216,6 +216,7 @@ export interface Config {
   record_sessions_percent: number;
   record_canvas: boolean;
   record_heatmap_data: boolean;
+  flags: string;
 }
 
 export type VerboseResponse =


### PR DESCRIPTION
This PR adds the `flags` property to the Config interface, since the Feature Flag docs state that it's supported since [v2.71.0](https://github.com/mixpanel/mixpanel-js/releases/tag/v2.71.0).