### PR TITLE
Fix types for api_routes record/flags

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -166,6 +166,8 @@ export interface Config {
     track?: string;
     engage?: string;
     groups?: string;
+    record?: string;
+    flags?: string;
   };
   api_method: string;
   api_transport: string;


### PR DESCRIPTION
Adds missing api_routes typings for record + flags to match runtime defaults.

Fixes #524