### PR TITLE
[DEV-72] chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -25,9 +25,9 @@ jobs:
       SAUCE_TUNNEL_NAME: ci-js-sdk-test-${{ matrix.browser }}-${{ github.run_id }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: 22.x
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,9 +19,9 @@ jobs:
         node-version: [20.x, 22.x, 24.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci


### PR DESCRIPTION
## Summary
Pin all GitHub Actions workflow steps to immutable full commit SHAs instead of mutable tags or branches.

## Why
Mutable tags can be moved after the fact, making it possible for a supply-chain attack to inject malicious code into CI. Pinning to a commit SHA ensures the exact version of an action is used, and the original tag is preserved as an inline comment for readability.

## Verification
Review the diff — all `uses:` lines with third-party actions should now reference a 40-character commit SHA with the original tag as an inline comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Linear: https://linear.app/mixpanel/issue/DEV-72/pin-all-github-actions-to-commit-shas