### PR TITLE
Session recording: measure record_min_ms from first user event

### DIFF
--- a/src/recorder/session-recording.js
+++ b/src/recorder/session-recording.js
@@ -281,10 +281,14 @@ SessionRecording.prototype.startRecording = function (shouldStopBatcher) {
                     this._onIdleTimeout();
                     return;
                 }
-                if (this._recordMinMsCheckStart === null) {
-                    this._recordMinMsCheckStart = ev.timestamp;
-                }
                 if (isUserEvent(ev)) {
+                    // Measure record_min_ms from the first user event, not the first rrweb event.
+                    // Initial Meta/FullSnapshot/Mutation events fire at page load before any
+                    // interaction, so anchoring on them would let an idle-then-click flush a
+                    // near-empty replay (see MULTI-436).
+                    if (this._recordMinMsCheckStart === null) {
+                        this._recordMinMsCheckStart = ev.timestamp;
+                    }
                     if (this.batcher.stopped && ev.timestamp - this._recordMinMsCheckStart >= this.recordMinMs) {
                         this.batcher.start();
                     }

--- a/tests/unit/session-recording.js
+++ b/tests/unit/session-recording.js
@@ -685,12 +685,56 @@ describe(`SessionRecording`, function() {
       clock.tick(2000);
       expect(rec.batcher.stopped).to.be.true;
 
-      // user event before record_min_ms should not start the batcher
+      // user event before record_min_ms (measured from first user event) should not start the batcher
       mockRrweb.emit(EventType.IncrementalSnapshot, IncrementalSource.MouseInteraction);
       expect(rec.batcher.stopped).to.be.true;
 
-      // after record_min_ms, a user event should start the batcher
-      clock.tick(4000);
+      // after record_min_ms has elapsed since the first user event, the next user event starts the batcher
+      clock.tick(recordMinMs);
+      mockRrweb.emit(EventType.IncrementalSnapshot, IncrementalSource.MouseMove);
+      expect(rec.batcher.stopped).to.be.false;
+
+      rec.stopRecording();
+    });
+
+    it(`measures record_min_ms from first user event, not first rrweb event`, async function() {
+      // Regression test for MULTI-436: page loads, rrweb emits initial Meta/FullSnapshot,
+      // user is idle past record_min_ms, then clicks once. Previously this immediately
+      // started the batcher and flushed a near-empty replay because the threshold was
+      // measured from the initial snapshot rather than from the first user activity.
+      const recordMinMs = 8000;
+      const customMixpanel = new MockMixpanelLib({'record_min_ms': recordMinMs});
+
+      const rec = new SessionRecording({
+        mixpanelInstance: customMixpanel,
+        replayId: `min-ms-idle-load-replay`,
+        rrwebRecord: mockRrweb.recordStub,
+        sharedLockStorage: localStorage,
+      });
+
+      rec.startRecording();
+      expect(rec.batcher.stopped).to.be.true;
+
+      // initial non-user events at page load (t=0)
+      mockRrweb.emit(EventType.Meta);
+      mockRrweb.emit(EventType.FullSnapshot);
+
+      // user is idle for longer than record_min_ms, then interacts once
+      clock.tick(recordMinMs + 1000);
+      mockRrweb.emit(EventType.IncrementalSnapshot, IncrementalSource.MouseInteraction);
+
+      // batcher must NOT start: there has only been one user event so far,
+      // so the recorded user-activity window is 0ms, well below record_min_ms.
+      expect(rec.batcher.stopped).to.be.true;
+
+      // another user event still inside record_min_ms (measured from the first
+      // user event) must also keep the batcher stopped.
+      clock.tick(recordMinMs - 1);
+      mockRrweb.emit(EventType.IncrementalSnapshot, IncrementalSource.MouseMove);
+      expect(rec.batcher.stopped).to.be.true;
+
+      // one more tick crosses record_min_ms from the first user event; batcher starts.
+      clock.tick(2);
       mockRrweb.emit(EventType.IncrementalSnapshot, IncrementalSource.MouseMove);
       expect(rec.batcher.stopped).to.be.false;
 


### PR DESCRIPTION
## Summary

`record_min_ms` is supposed to suppress sub-threshold session replays, but it currently leaks short replays in a common pattern. This PR fixes the gate and adds a regression test.

## The bug

In [`src/recorder/session-recording.js`](src/recorder/session-recording.js), the `record_min_ms` gate inside the rrweb `emit` handler initializes `_recordMinMsCheckStart` on the **first event of any type**:

```js
if (this._recordMinMsCheckStart === null) {
    this._recordMinMsCheckStart = ev.timestamp;
}
if (isUserEvent(ev)) {
    if (this.batcher.stopped && ev.timestamp - this._recordMinMsCheckStart >= this.recordMinMs) {
        this.batcher.start();
    }
    ...
}
```

The first rrweb event on a page load is almost always a non-user `Meta` / `FullSnapshot` / `Mutation` snapshot. So the threshold ends up being measured against **wall-clock time since the page loaded**, not against the duration of any actual user activity.

Concrete failure mode (reported in an SRFE; customer hardcodes `record_min_ms: 8000`):
1. Page loads → rrweb emits `Meta` at `t=0`. `_recordMinMsCheckStart = 0`.
2. User idles for 10s without interacting.
3. User clicks once at `t=10000`. `isUserEvent` is true, `10000 - 0 >= 8000`, batcher starts.
4. A near-empty batch flushes with `replay_length_ms` reflecting one event. The server has no minimum-duration check, so the short replay is ingested and the player faithfully shows it.

## The fix

Move `_recordMinMsCheckStart` initialization inside the `isUserEvent` branch so the gate is anchored to the first user-activity event. That matches both the customer's mental model ("the recording is the user's session") and how the player computes duration.

## Tests

- New regression test `measures record_min_ms from first user event, not first rrweb event` exercises the idle-then-click sequence above. Without the fix it fails: the batcher starts on the first user event after the idle gap.
- The existing test `batcher stays stopped until record_min_ms elapses even with non-user events` previously had timings that only passed under the buggy behavior (the second user event landed `recordMinMs` ms after the initial Meta, not after the first user event). Adjusted the second `clock.tick` so the assertion holds under the corrected, intent-matching behavior. The test's stated intent ("non-user events shouldn't count") is now actually enforced.
- Full `npm run unit-test` passes: 681/681.

Filed for tracking as MULTI-436 in our internal Linear; no external issue link.

## Test plan

- [x] `npm run lint`
- [x] `npm run unit-test`
- [ ] Manual: load a page with `mixpanel.init(TOKEN, { record_sessions_percent: 100, record_min_ms: 8000 })`, idle 10s without interacting, click once, close tab. Confirm no replay surfaces.
- [ ] Manual: same config, interact continuously for 10s. Confirm the replay shows up and `replay_length_ms` ≥ 8000.

_Assisted by Claude_