### PR TITLE
Add support for Node 26

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [20.x, 22.x, 24.x, 26.x]
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "homepage": "https://github.com/mixpanel/mixpanel-js",
   "engines": {
-    "node": ">=20 <26"
+    "node": ">=20 <=26"
   },
   "devDependencies": {
     "@ampproject/rollup-plugin-closure-compiler": "0.27.0",


### PR DESCRIPTION
Closes #603

Hi! 👋 Our team recently upgraded to Node 26 and we've continued to use `mixpanel-js` without issue despite there not being official support for this version of Node. Wanted to contribute and formalize support!

## What's changed
- Updated `engines.node` to support Node versions `>= 20 <=26`
- Added `26.x` to the unit-tests CI matrix so it stays covered going forward

## Testing
Ran these checks locally on Node v26.4.0:

- `npm run test:ci`
- `npm run build-dist`

Happy to adjust anything (I left the `openfeature-provider-tests.yml` CI check untouched bc it hasn't been updated to support Node 24) - just let me know. Thanks for maintaining this package!