### PR TITLE
Fix: encodeDates mutates the object passed to people.set (#479)

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -328,14 +328,18 @@ _.isElement = function(obj) {
 };
 
 _.encodeDates = function(obj) {
+    // build a copy so the caller's object (and any nested objects) are not mutated
+    var encoded = _.isArray(obj) ? [] : {};
     _.each(obj, function(v, k) {
         if (_.isDate(v)) {
-            obj[k] = _.formatDate(v);
+            encoded[k] = _.formatDate(v);
         } else if (_.isObject(v)) {
-            obj[k] = _.encodeDates(v); // recurse
+            encoded[k] = _.encodeDates(v); // recurse
+        } else {
+            encoded[k] = v;
         }
     });
-    return obj;
+    return encoded;
 };
 
 _.timestamp = function() {

--- a/tests/unit/utils.js
+++ b/tests/unit/utils.js
@@ -533,3 +533,28 @@ describe(`_.localStorage / _.sessionStorage wrappers`, function() {
     expect(function() { wrapper.is_supported(true); }).to.not.throw();
   });
 });
+
+describe(`_.encodeDates`, function() {
+  it(`encodes top-level Date values`, function() {
+    const encoded = _.encodeDates({ created: new Date(Date.UTC(2020, 0, 2, 3, 4, 5)) });
+    expect(encoded.created).to.equal(`2020-01-02T03:04:05`);
+  });
+
+  it(`encodes nested Date values`, function() {
+    const encoded = _.encodeDates({ meta: { created: new Date(Date.UTC(2020, 0, 2, 3, 4, 5)) } });
+    expect(encoded.meta.created).to.equal(`2020-01-02T03:04:05`);
+  });
+
+  it(`does not mutate the object passed in`, function() {
+    const original = { created: new Date(Date.UTC(2020, 0, 2, 3, 4, 5)) };
+    _.encodeDates(original);
+    expect(_.isDate(original.created)).to.be.true;
+  });
+
+  it(`does not mutate nested Date values on the object passed in`, function() {
+    const nestedDate = new Date(Date.UTC(2020, 0, 2, 3, 4, 5));
+    const original = { meta: { created: nestedDate } };
+    _.encodeDates(original);
+    expect(_.isDate(original.meta.created)).to.be.true;
+  });
+});


### PR DESCRIPTION
### What I hit

I passed a `Date` to `mixpanel.people.set(...)` and the `Date` on my **own** object silently turned into a string on the next render, which broke a date-picker bound to that object. This is issue #479.

Minimal repro:
```js
var props = { created: new Date('2020-01-02T03:04:05Z') };
mixpanel.people.set(props);
props.created; // "2020-01-02T03:04:05"  <- mutated in place, no longer a Date
```

### Why

`_.encodeDates` (`src/utils.js`) writes the encoded strings back onto the object it is given (`obj[k] = _.formatDate(v)`) and recurses onto the same nested references, so it edits the exact object the caller passed to `people.set` / `set_once` (and group `set`).

### Fix

Build a copy instead of mutating the input. The encoded output is identical to before; only the side effect on the caller's object is removed. (`_.isObject` excludes arrays, so recursion still only descends into plain objects.)

### Test

Added cases to `tests/unit/utils.js`: encoding still works (top-level + nested) and the input object is no longer mutated (top-level + nested). Full `tests/unit/*` suite passes (684 passing, 0 failing) and `eslint ./src` is clean.

Closes #479.
