### PR TITLE
fix: correct Android Mobile browserVersion regex casing (null $browser_version on Android)

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1548,7 +1548,7 @@ _.info = {
             'Firefox iOS': /FxiOS\/(\d+(\.\d+)?)/,
             'Konqueror': /Konqueror:(\d+(\.\d+)?)/,
             'BlackBerry': /BlackBerry (\d+(\.\d+)?)/,
-            'Android Mobile': /android\s(\d+(\.\d+)?)/,
+            'Android Mobile': /Android\s(\d+(\.\d+)?)/,
             'Samsung Internet': /SamsungBrowser\/(\d+(\.\d+)?)/,
             'Internet Explorer': /(rv:|MSIE )(\d+(\.\d+)?)/,
             'Mozilla': /rv:(\d+(\.\d+)?)/,

--- a/tests/unit/utils.js
+++ b/tests/unit/utils.js
@@ -204,6 +204,20 @@ describe(`_.info helper methods`, function() {
       expect(pageViewProperties.current_url_search).to.equal(`?utm_source=google`);
     });
   });
+
+  describe(`_.info.browserVersion`, function() {
+    // Real Samsung stock browser UA on Android 4.4.2 (no "Chrome" token, so
+    // it is detected as "Android Mobile" rather than "Chrome").
+    var androidMobileUA = `Mozilla/5.0 (Linux; U; Android 4.4.2; en-us; SAMSUNG SM-G900F Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36`;
+
+    it(`detects "Android Mobile" browsers`, function() {
+      expect(_.info.browser(androidMobileUA, ``, false)).to.equal(`Android Mobile`);
+    });
+
+    it(`parses the version for "Android Mobile" browsers`, function() {
+      expect(_.info.browserVersion(androidMobileUA, ``, false)).to.equal(4.4);
+    });
+  });
 });
 
 describe(`_.isBlockedUA`, function() {


### PR DESCRIPTION
## What

The `versionRegexs` lookup in `src/utils.js` used a lowercase, unflagged pattern for the `Android Mobile` browser:

```js
'Android Mobile': /android\s(\d+(\.\d+)?)/,
```

Real Android user agent strings spell the token with a capital `Android` (for example `Mozilla/5.0 (Linux; U; Android 4.4.2; ...)`), so this regex never matched. `_.info.browserVersion()` therefore returned `null` for these browsers. This changes the pattern to match the actual casing, consistent with every other place the same token is referenced:

```js
'Android Mobile': /Android\s(\d+(\.\d+)?)/,
```

For reference, the sibling references already use the capitalized form: `browser()` (`_.includes(user_agent, 'Android')`), `os()` (`/Android/.test(a)`), and `device()` (`/Android/.test(user_agent)`).

## Why (what I hit)

I was looking at my Android traffic in Mixpanel and noticed `$browser_version` coming through as null for a slice of users. The affected ones were non-Chrome Android browsers (older stock/WebView user agents classified as `Android Mobile` rather than `Chrome`). Those get their version parsed by the `Android Mobile` regex, which never matched because of the lowercase `android`, so every one recorded a null `$browser_version`. Chrome-on-Android was fine because it matches the separate `Chrome/...` pattern.

## Test

Added a regression test in `tests/unit/utils.js` using a real Android 4.4.2 Samsung stock browser user agent (classified as `Android Mobile`, not Chrome), asserting `_.info.browser(ua, '', false)` equals `Android Mobile` and `_.info.browserVersion(ua, '', false)` equals `4.4`. Before the fix the version assertion fails with `expected null to equal 4.4`. After the fix both pass. `npm run unit-test` -> 682 passing, `npm run lint` clean.
