### PR TITLE
ci(dependabot): scope npm version updates to production deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,23 @@
 # .github/dependabot.yml
 version: 2
 updates:
-  - package-ecosystem: "npm" # Or "yarn"
-    directory: "/" # Tells Dependabot to scan root directory only
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
       interval: "daily"
     cooldown:
       default-days: 30
+    # Only open version-update PRs for production (runtime) dependencies.
+    # Development-scoped deps are intentionally out of scope: they are not
+    # distributed to consumers, and their alerts are auto-dismissed via the
+    # scope:development Dependabot rule. This keeps both surfaces consistent.
+    allow:
+      - dependency-type: "production"
+    open-pull-requests-limit: 5
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 30
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## What

Tightens `.github/dependabot.yml` so Dependabot's **version-update PRs** are scoped and bounded:

- **`allow: dependency-type: "production"`** on the npm ecosystem — only open PRs for the **5 runtime dependencies**, not the ~40 dev-tooling packages.
- **`open-pull-requests-limit: 5`** on both npm and github-actions.
- Removes a stale `# Or "yarn"` comment.

## Why

This mirrors the `scope:development` Dependabot auto-dismiss rule already in place: dev-scoped **alerts** are suppressed, so dev-scoped **update PRs** shouldn't be generated either. Same philosophy on both surfaces — dev tooling isn't distributed to consumers, so it's intentionally out of Dependabot's update scope.

It also addresses the current PR firehose (the repo had ~10 open Dependabot version-update PRs, most for dev tooling).

## Note: no grouping (intentional)

This scopes *which* deps are tracked; it does **not** group updates. Each production update still arrives as its own **atomic, independently-reviewable and revertable** PR — no batch-coupling where one bad bump blocks the rest.

## Scope

- Config-only, single file. No effect on the published package or runtime.
- Does not retroactively close existing dev-tooling update PRs (those can be closed manually); it prevents new ones going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
