### PR TITLE
ci(sbom): attach SBOM to a draft release (fix immutable-releases incompatibility)

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,14 +1,22 @@
 name: SBOM
 
 # Generate a CycloneDX SBOM for the published (production) dependency tree and
-# attach it to the GitHub Release. Forward-only: fires on newly published
-# releases; past releases are not backfilled.
+# attach it to a DRAFT GitHub Release for the pushed tag. The release maintainer
+# reviews and publishes the draft, which finalizes it as an immutable, attested
+# release with the SBOM already included.
+#
+# Why a draft instead of upload-on-publish: with Immutable Releases enabled, a
+# release's asset list is frozen at publish time, so an asset cannot be added
+# after `release: published` (GitHub returns HTTP 422). Attaching the SBOM while
+# the release is still a draft is the only way to include it. The manual
+# `npm publish` + 2FA flow is unaffected — this only touches the GitHub Release.
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
 
 permissions:
-  contents: write  # upload the SBOM as a release asset
+  contents: write  # create the draft release + attach the SBOM asset
 
 jobs:
   sbom:
@@ -25,11 +33,10 @@ jobs:
 
       - name: Generate CycloneDX SBOM (production deps only)
         env:
-          SBOM_FILE: mixpanel-browser-${{ github.event.release.tag_name }}.cdx.json
-        # cyclonedx-npm is pinned in devDependencies and installed by `npm ci` above,
-        # so it runs from node_modules with no network fetch (respects .npmrc yes=false).
-        # --omit dev matches what consumers install; --validate fails the job if the
-        # SBOM is not schema-valid CycloneDX.
+          SBOM_FILE: mixpanel-browser-${{ github.ref_name }}.cdx.json
+        # cyclonedx-npm is pinned in devDependencies and installed by `npm ci`.
+        # --omit dev matches what consumers install; --validate fails the job if
+        # the SBOM is not schema-valid CycloneDX.
         run: |
           npx cyclonedx-npm \
             --omit dev \
@@ -38,8 +45,20 @@ jobs:
             --output-format JSON \
             --output-file "$SBOM_FILE"
 
-      - name: Attach SBOM to the release
+      - name: Attach SBOM to a draft release for the tag
         env:
           GH_TOKEN: ${{ github.token }}
-          SBOM_FILE: mixpanel-browser-${{ github.event.release.tag_name }}.cdx.json
-        run: gh release upload "${{ github.event.release.tag_name }}" "$SBOM_FILE" --clobber
+          SBOM_FILE: mixpanel-browser-${{ github.ref_name }}.cdx.json
+        # Create a DRAFT release (or reuse an existing draft) and attach the SBOM
+        # while the release is still mutable. The maintainer publishes the draft
+        # manually, which finalizes the immutable + attested release with the SBOM
+        # already included.
+        run: |
+          if gh release view "${{ github.ref_name }}" >/dev/null 2>&1; then
+            gh release upload "${{ github.ref_name }}" "$SBOM_FILE" --clobber
+          else
+            gh release create "${{ github.ref_name }}" "$SBOM_FILE" \
+              --draft \
+              --title "${{ github.ref_name }}" \
+              --generate-notes
+          fi


### PR DESCRIPTION
## Problem

The SBOM workflow added in #613 never actually attaches the SBOM on this repo. It triggers on `release: published` and runs `gh release upload` **after** the release exists — but with **Immutable Releases** enabled (which powers this repo's release attestations), a release's asset list is frozen at publish time. The upload fails:

```
HTTP 422: Cannot upload assets to an immutable release
```

Confirmed on a throwaway pre-release ([run 32299497744](https://github.com/mixpanel/mixpanel-js/actions/runs/32299497744)); real releases are immutable too (`gh api repos/mixpanel/mixpanel-js/releases/tags/v2.82.0 --jq .immutable` → `true`).

## Fix

Attach the SBOM while the release is still a **draft** (mutable), then let the maintainer publish it — publishing finalizes the immutable + attested release with the SBOM already inside.

- **Trigger:** tag push (`v*`) instead of `release: published`.
- **Action:** generate the SBOM, then create a **draft** release for the tag with the SBOM attached (reusing an existing draft if present).
- **Unchanged:** the manual `npm publish` + 2FA flow. This only touches the GitHub Release side — no npm token, no automated publish, no provenance.

## Process change (one line)

Push the tag → the workflow creates a **draft** release with the SBOM → maintainer reviews/edits notes and clicks **Publish**. (Replaces "push tag → create release from scratch.")

## Verified end-to-end

Tested on a throwaway tag before opening this ([run 32302323306](https://github.com/mixpanel/mixpanel-js/actions/runs/32302323306)): `Attach SBOM to a draft release` step **succeeded**, a draft release was created with `mixpanel-browser-<tag>.cdx.json` attached, and the asset validated as CycloneDX 1.6 (root `mixpanel-browser@2.82.0`, 5 runtime deps, 16 components). Throwaway draft + tag deleted afterward.
