### PR TITLE
2.82.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+**2.82.1** (19 Aug 2026)
+
+- Publishes a CycloneDX Software Bill of Materials (SBOM) as a release asset.
+- Bumps the transitive `postcss` and `nanoid` dependencies to patched versions. The published bundle is unchanged — a fresh install already resolved to the patched versions.
+
 **2.82.0** (10 Aug 2026)
 
 - Fixes empty response bodies in session recording network telemetry. Fetch events were emitted before the response body finished being read; they now wait for it. The application's own `fetch()` is not delayed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mixpanel-browser",
-  "version": "2.82.0",
+  "version": "2.82.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mixpanel-browser",
-      "version": "2.82.0",
+      "version": "2.82.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@mixpanel/rrweb": "2.0.0-alpha.18.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mixpanel-browser",
-  "version": "2.82.0",
+  "version": "2.82.1",
   "description": "The official Mixpanel JavaScript browser client library",
   "main": "dist/mixpanel.cjs.js",
   "module": "dist/mixpanel.module.js",

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 export var Config = {
     DEBUG: false,
-    LIB_VERSION: '2.82.0'
+    LIB_VERSION: '2.82.1'
 };
 
 // Window global names for async modules


### PR DESCRIPTION
## Purpose

Cuts a `2.82.1` release so the CycloneDX **SBOM ships as a release asset** (via the tag-triggered SBOM workflow, #623). Also refreshes the transitive `postcss`/`nanoid` pins to their patched versions.

**No functional changes for consumers** — a fresh `npm install` already resolved to the patched `postcss`/`nanoid`, and the shipped bundle is byte-identical. This is effectively an administrative/attestation release.

## Source bump (this PR)

- `package.json` + `package-lock.json` → `2.82.1`
- `src/config.js` `LIB_VERSION` → `2.82.1`
- `CHANGELOG.md` entry

## Not included: `dist/`

The `dist/` bundles embed `LIB_VERSION` (content-hashed filenames), so they change on a version bump — but they're **generated output**. I intentionally left them out so this PR stays reviewable; the release build (`npm run build-dist` / `prepublishOnly`) regenerates them with `2.82.1` as part of cutting the release, matching the normal flow.

## To release (maintainer, unchanged 2FA flow)

1. Merge this PR
2. `npm run build-dist` (regenerates `dist/` at `2.82.1`) and `npm publish` **with 2FA**
3. Push tag `v2.82.1` → the SBOM workflow creates a **draft** release with the SBOM attached
4. Review the draft and click **Publish** → immutable + attested release with the SBOM inside

