### PR TITLE
ci(sbom): attach SBOM at release creation (fix immutable-releases 422)

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,64 +1,35 @@
 name: SBOM
 
-# Generate a CycloneDX SBOM for the published (production) dependency tree and
-# attach it to a DRAFT GitHub Release for the pushed tag. The release maintainer
-# reviews and publishes the draft, which finalizes it as an immutable, attested
-# release with the SBOM already included.
+# The CycloneDX SBOM is generated and attached to the release AT CREATION time
+# (see the `sbom` script in package.json and the release process). It cannot be
+# attached after publish: Immutable Releases freeze a release's asset list, so a
+# post-publish `gh release upload` returns HTTP 422. This workflow therefore does
+# NOT attach anything — it only VERIFIES that a published release carries its SBOM,
+# and warns if it doesn't.
 #
-# Why a draft instead of upload-on-publish: with Immutable Releases enabled, a
-# release's asset list is frozen at publish time, so an asset cannot be added
-# after `release: published` (GitHub returns HTTP 422). Attaching the SBOM while
-# the release is still a draft is the only way to include it. The manual
-# `npm publish` + 2FA flow is unaffected — this only touches the GitHub Release.
+# Release step (in the release tooling): after `npm ci`, run
+#   npm run sbom
+# then include the generated `mixpanel-browser-<version>.cdx.json` as an asset when
+# the release is CREATED, e.g. `gh release create <tag> ... mixpanel-browser-*.cdx.json`.
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 permissions:
-  contents: write  # create the draft release + attach the SBOM asset
+  contents: read
 
 jobs:
-  sbom:
+  verify-sbom:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-      - name: Use Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
-        with:
-          node-version: 22.x
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Generate CycloneDX SBOM (production deps only)
-        env:
-          SBOM_FILE: mixpanel-browser-${{ github.ref_name }}.cdx.json
-        # cyclonedx-npm is pinned in devDependencies and installed by `npm ci`.
-        # --omit dev matches what consumers install; --validate fails the job if
-        # the SBOM is not schema-valid CycloneDX.
-        run: |
-          npx cyclonedx-npm \
-            --omit dev \
-            --mc-type library \
-            --validate \
-            --output-format JSON \
-            --output-file "$SBOM_FILE"
-
-      - name: Attach SBOM to a draft release for the tag
+      - name: Verify the release has a CycloneDX SBOM asset
         env:
           GH_TOKEN: ${{ github.token }}
-          SBOM_FILE: mixpanel-browser-${{ github.ref_name }}.cdx.json
-        # Create a DRAFT release (or reuse an existing draft) and attach the SBOM
-        # while the release is still mutable. The maintainer publishes the draft
-        # manually, which finalizes the immutable + attested release with the SBOM
-        # already included.
+          TAG: ${{ github.event.release.tag_name }}
         run: |
-          if gh release view "${{ github.ref_name }}" >/dev/null 2>&1; then
-            gh release upload "${{ github.ref_name }}" "$SBOM_FILE" --clobber
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets \
+               --jq '.assets[].name' | grep -q '\.cdx\.json$'; then
+            echo "✅ SBOM asset present on release $TAG."
           else
-            gh release create "${{ github.ref_name }}" "$SBOM_FILE" \
-              --draft \
-              --title "${{ github.ref_name }}" \
-              --generate-notes
+            echo "::warning title=SBOM missing::No CycloneDX SBOM (*.cdx.json) is attached to release $TAG. Generate it with 'npm run sbom' and attach it when the release is CREATED — assets cannot be added after publish (immutable releases)."
           fi

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build-watch:full": "FULL=1 npx rollup -c rollup.config.mjs -w",
     "build-dist": "DIST=1 ./build.sh",
     "build-full": "FULL=1 ./build.sh",
+    "sbom": "cyclonedx-npm --omit dev --mc-type library --validate --output-format JSON --output-file mixpanel-browser-$npm_package_version.cdx.json",
     "build-test-polyfill": "webpack tests/vendor/core-js-polyfills.src.js  tests/vendor/core-js-polyfills.js",
     "build-browser-tests": "npx rollup -c tests/browser/client/rollup.config.mjs -w",
     "dox": "node doc/build-docs.js",


### PR DESCRIPTION
## Root cause of the `v2.82.1` failure

The SBOM action ([run 32401457410](https://github.com/mixpanel/mixpanel-js/actions/runs/32401457410)) ran on the `v2.82.1` tag push, but the release was **already published** — and with **Immutable Releases** enabled, GitHub freezes a release's asset list at publish time:

```
gh release upload "v2.82.1" ... --clobber
HTTP 422: Cannot upload assets to an immutable release.
```

Timeline: release published `18:07:32Z` → SBOM job started `18:07:34Z`. It was 2 seconds too late.

It passed in testing because that test pushed a *bare* tag (no release existed yet, so the action created the draft itself). The real release publishes directly, so a reactive tag-triggered workflow is always too late.

## Proposed solution: attach at creation

A reactive workflow can't win against a directly-published immutable release — the SBOM has to be an asset **when the release is created**. This PR does the repo-side of that:

- **`npm run sbom`** — a reusable command that generates the production-scoped CycloneDX SBOM to `mixpanel-browser-<version>.cdx.json` (pinned `cyclonedx-npm`, `--omit dev --validate`). Verified locally: valid CycloneDX 1.6, 5 runtime deps.
- **`sbom.yml` reworked** — it no longer tries to attach (that's what 422'd). It now runs on `release: published` and only **verifies** the SBOM asset is present, warning if it's missing.

## The one piece that's yours (release tooling)

In the release step (after `npm ci`), run `npm run sbom` and include the file as an asset when the release is **created** — e.g.:

```bash
npm run sbom
gh release create "v<version>" <notes…> mixpanel-browser-<version>.cdx.json
```

Wherever that lands in the `mix sdk` / release flow is your call — it just needs to attach the file at creation rather than after. Happy to pair on wiring it in.

## `v2.82.1`

Already published without the SBOM and immutable, so it can't be edited. Simplest is to leave it and let the SBOM land on the next release once the release step calls `npm run sbom`.
