### PR TITLE
fix(security): resolve js/polynomial-redos in _.trim (CodeQL #161)

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -35,8 +35,11 @@ var nativeBind = FuncProto.bind,
 
 var _ = {
     trim: function(str) {
-        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim#Polyfill
-        return str.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '');
+        // Native String.prototype.trim strips the same set as the former regex
+        // (ECMAScript WhiteSpace + LineTerminator, which includes NBSP \xA0 and
+        // BOM \uFEFF) in linear time, avoiding the polynomial backtracking of an
+        // anchored alternation regex (CodeQL js/polynomial-redos).
+        return str.trim();
     }
 };
 

--- a/tests/unit/utils.js
+++ b/tests/unit/utils.js
@@ -44,6 +44,35 @@ describe(`extract_domain`, function() {
   });
 });
 
+describe(`_.trim`, function() {
+  it(`strips leading and trailing ASCII whitespace`, function() {
+    expect(_.trim(`  hello  `)).to.equal(`hello`);
+    expect(_.trim(`\t\n hi \r\n`)).to.equal(`hi`);
+  });
+
+  it(`preserves interior whitespace`, function() {
+    expect(_.trim(`  a b  c  `)).to.equal(`a b  c`);
+  });
+
+  it(`strips non-breaking space (\\xA0) and BOM (\\uFEFF), matching the former regex`, function() {
+    expect(_.trim(`\uFEFF\xA0text\xA0\uFEFF`)).to.equal(`text`);
+  });
+
+  it(`returns an empty string for all-whitespace input`, function() {
+    expect(_.trim(`\t \uFEFF\xA0 \n`)).to.equal(``);
+  });
+
+  it(`runs in linear time on adversarial whitespace (no polynomial ReDoS)`, function() {
+    // The former anchored-alternation regex backtracked on long runs of \t
+    // followed by a non-space (CodeQL js/polynomial-redos). Guard against a
+    // regression to a super-linear implementation.
+    var input = new Array(200001).join(`\t`) + `x`;
+    var start = Date.now();
+    expect(_.trim(input)).to.equal(`x`);
+    expect(Date.now() - start).to.be.lessThan(1000);
+  });
+});
+
 describe(`_.info helper methods`, function() {
   beforeEach(resetTestingState);
   afterEach(resetTestingState);


### PR DESCRIPTION
## What & why

CodeQL alert **#161** (`js/polynomial-redos`, high) flags the `_.trim` polyfill in `src/utils.js`:

```js
str.replace(/^[\s﻿\xA0]+|[\s﻿\xA0]+$/g, '')
```

The anchored-alternation regex backtracks in **O(n²)** on a long run of `\t` followed by a non-space. This is reachable from **attacker-influenceable input**: autocapture passes element `textContent` through `_.trim` (`src/autocapture/utils.js`).

## Change

Replace it with native `String.prototype.trim()`.

- **Behavior is identical.** Native `trim()` strips exactly the ECMAScript *WhiteSpace + LineTerminator* set, which includes NBSP (`\xA0`) and BOM (`﻿`) — the same characters the old regex targeted — in linear time.
- **No new browser-support assumption.** The codebase already calls native `.trim()` in `src/autocapture/utils.js` and `src/recorder/session-recording.js`.
- Source-only change; no product/behavior change.

## Testing

- `npm run lint` — clean
- `npm run unit-test` — **686 passing, 0 failing**
- New `_.trim` unit suite (5 tests): whitespace handling, interior preservation, `\xA0`/`﻿` equivalence to the former regex, all-whitespace input, and a linear-time guard (200k `\t`) that fails if a super-linear implementation ever regresses.

## Impact

Resolves CodeQL **#161**. Since `dist/` is rebuilt from `src/` at release time, the corresponding `dist/*` alert clears on the next release rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)