### PR TITLE
fix(security): complete param escaping in _.getQueryParam (CodeQL #157/158/159/160/199/200)

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -921,7 +921,11 @@ _.HTTPBuildQuery = function(formdata, arg_separator) {
 _.getQueryParam = function(url, param) {
     // Expects a raw URL
 
-    param = param.replace(/[[]/g, '\\[').replace(/[\]]/g, '\\]');
+    // Escape the RegExp metacharacters the param name may contain before
+    // interpolating it into `regexS`. Backslash is escaped in the same pass as
+    // the brackets (a single character class), so a param name is never able to
+    // introduce an unintended escape sequence (CodeQL js/incomplete-sanitization).
+    param = param.replace(/[[\]\\]/g, '\\$&');
     var regexS = '[\\?&]' + param + '=([^&#]*)',
         regex = new RegExp(regexS),
         results = regex.exec(url);

--- a/tests/unit/utils.js
+++ b/tests/unit/utils.js
@@ -44,6 +44,34 @@ describe(`extract_domain`, function() {
   });
 });
 
+describe(`_.getQueryParam`, function() {
+  it(`extracts a parameter value from a URL`, function() {
+    expect(_.getQueryParam(`https://example.com/?foo=bar&baz=qux`, `foo`)).to.equal(`bar`);
+    expect(_.getQueryParam(`https://example.com/?foo=bar&baz=qux`, `baz`)).to.equal(`qux`);
+  });
+
+  it(`returns an empty string when the parameter is absent`, function() {
+    expect(_.getQueryParam(`https://example.com/?foo=bar`, `missing`)).to.equal(``);
+  });
+
+  it(`URL-decodes values and converts + to space`, function() {
+    expect(_.getQueryParam(`https://example.com/?q=hello+world%21`, `q`)).to.equal(`hello world!`);
+  });
+
+  it(`treats bracket metacharacters in the param name literally`, function() {
+    // Brackets in the name must match literally, not as a regex character class.
+    expect(_.getQueryParam(`https://example.com/?a[b]=c`, `a[b]`)).to.equal(`c`);
+    expect(_.getQueryParam(`https://example.com/?ab=c`, `a[b]`)).to.equal(``);
+  });
+
+  it(`escapes backslashes in the param name (CodeQL js/incomplete-sanitization)`, function() {
+    // Regression guard: with the former escaping, a backslash in the param name
+    // interpolated unescaped into the RegExp (e.g. `\b` became a word boundary),
+    // so this lookup failed to match. Escaping backslash makes it match literally.
+    expect(_.getQueryParam(`https://example.com/?a\\b=z`, `a\\b`)).to.equal(`z`);
+  });
+});
+
 describe(`_.info helper methods`, function() {
   beforeEach(resetTestingState);
   afterEach(resetTestingState);


### PR DESCRIPTION
## What & why

CodeQL `js/incomplete-sanitization` (message: *"This does not escape backslash characters in the input"*) flags `_.getQueryParam` in `src/utils.js`:

```js
param = param.replace(/[[]/g, '\\[').replace(/[\]]/g, '\\]');
var regexS = '[\\?&]' + param + '=([^&#]*)',
    regex = new RegExp(regexS);
```

The param name is escaped for `[` and `]` but **not backslash**, so a backslash in the name would be interpolated unescaped into the constructed `RegExp`.

## Exploitability: low today, correctness fix

Every current caller passes a **hardcoded literal** name — `CAMPAIGN_KEYWORDS`, `CLICK_IDS` (`src/utils.js:1420/1436`), and `'q'`/`'p'` (`:1465`). The unescaped value is never attacker-controlled, so there is **no known exploit**. This completes the sanitizer so it's correct for any future caller, and clears the finding permanently rather than annotating it.

## Change

Escape brackets **and** backslash in one pass:

```js
param = param.replace(/[[\]\\]/g, '\\$&');
```

Output is **byte-identical** to the old code for any input without a backslash (`[`→`\[`, `]`→`\]`), so behavior for all current callers is unchanged.

## Testing

- `npm run lint` — clean
- `npm run unit-test` — **686 passing, 0 failing**
- New `_.getQueryParam` suite (previously untested): extraction, absent param, URL-decode/`+`→space, literal-bracket matching, and a **failing-before/passing-after** backslash regression guard. Verified the old escaping returns `""` and the new returns `"z"` for the guard case.

## Impact

Resolves CodeQL **#157, #158, #159, #160, #199, #200** — one source root duplicated across the targeting and async-modules bundles. Since `dist/` is rebuilt from `src/` at release, the `dist/*` alerts clear on the next release rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)