### PR TITLE
ci(codeql): advanced setup scoped to first-party source

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,28 @@
+name: "mixpanel-js CodeQL config"
+
+# Scope CodeQL to first-party runtime source.
+#
+# Generated build output (dist/, build/), sample code (examples/), tests, and
+# build/dev tooling are excluded. This matches the accepted-risk scope in the
+# org security policy (mixpanel/.github SECURITY.md): dev/build dependencies,
+# sample/example code, and repo-lockfile scan findings are out of scope, and the
+# SBOM is the basis for supply-chain assessment.
+#
+# dist/ is generated from src/ at release time and vendors third-party code
+# (e.g. @mixpanel/rrweb). Scanning it duplicated every source finding across 6+
+# bundle variants and surfaced third-party issues we do not hand-edit in the
+# generated output. First-party issues are fixed at their source in src/;
+# third-party issues in the shipped bundle are tracked via the SBOM + VEX.
+
+paths-ignore:
+  - dist
+  - build
+  - examples
+  - doc
+  - vendor
+  - tests
+  - packages/*/test
+  - testServer.js
+  - rollup.config.mjs
+  - build.sh
+  - "**/*.min.js"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,54 @@
+name: "CodeQL"
+
+# Advanced CodeQL setup for mixpanel-js.
+#
+# Replaces GitHub default setup so analysis can be scoped to first-party runtime
+# source via .github/codeql/codeql-config.yml (default setup does not honor a
+# path-filter config). The query suite is left at the CodeQL default to preserve
+# parity with the previous default-setup coverage — this change re-scopes what is
+# analyzed, it does not change which queries run.
+#
+# NOTE: GitHub default setup must be disabled for this workflow to upload
+# results (Settings -> Advanced Security -> CodeQL analysis -> switch to
+# Advanced). See the PR description for the migration steps.
+
+on:
+  push:
+    branches: [master, "**/*-rc"]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: "31 5 * * 1" # weekly, Monday 05:31 UTC
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+          - language: actions
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@c16c0f3f2812ec4bb3750a5ed64873fe2ce0fbef # codeql-bundle-v2.26.3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@c16c0f3f2812ec4bb3750a5ed64873fe2ce0fbef # codeql-bundle-v2.26.3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What
SHA-pinned CodeQL **advanced setup** — workflow (`.github/workflows/codeql.yml`) + path-filter config (`.github/codeql/codeql-config.yml`) — scoping analysis to first-party runtime source (`src/`, `packages/*/src/`) and Actions workflows, excluding generated build output (`dist/`, `build/`), sample code (`examples/`), tests, and build/dev tooling.

## Why
Default setup can't honor a path-filter config and scans the committed `dist/` bundles, so every source finding is duplicated across 6+ bundle variants and third-party bundled code (e.g. `@mixpanel/rrweb`) surfaces as first-party. Excluded paths match the accepted-risk scope in `mixpanel/.github` SECURITY.md. **Query suite = CodeQL default (not extended)** — this re-scopes *what* is analyzed, not *which* queries run.

## Kept in sync
Identical config in both repos — change them together:
- public: **mixpanel/mixpanel-js#629**
- private: **mixpanel/mixpanel-js-private#484**

## ⚠️ Migration (admin) — required; also the answer to "how do I test this"
Merging alone isn't enough: default setup and advanced setup can't both upload, so this workflow's `Analyze` checks fail until default setup is turned off.
1. **Settings → Advanced Security → Code scanning → CodeQL analysis → switch Default → Advanced** (disables default setup).
2. The workflow then uploads — check *Security → Code scanning*: alerts re-scope to first-party `src/` (the `dist/`/`examples/`/`tests/` duplicates drop off).
3. Reversible — flip back to Default if it looks wrong.

_Prepped for next-week follow-up (Scot + Jakub)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)