### PR TITLE
chore(npm): stop shipping dev/build/test tooling in the published package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,20 @@ build
 examples
 tests
 vendor
+
+# Dev/build/test tooling — not used by consumers of the published package.
+# Keeps the npm tarball to shipped runtime code (dist/, src/) and docs, and
+# keeps dev-only files (incl. a local test server and build configs) out of the
+# published surface that a consumer's scanner would otherwise flag.
+.babelrc
+.eslintignore
+.eslintrc.json
+.jshintignore
+.jshintrc
+.github
+.vscode
+.claude
+build.sh
+rollup.config.mjs
+tsconfig.base.json
+testServer.js


### PR DESCRIPTION
## What

Extends `.npmignore` so the npm tarball contains only shipped runtime code (`dist/`, `src/`) and docs — removing dev/build/test tooling that was leaking into the published package.

## Why

`mixpanel-browser` has no `files` allowlist, so a lot of dev-only files ship to consumers, including a **local test server** (`testServer.js`) and **build configs** (`rollup.config.mjs`, `build.sh`, `tsconfig.base.json`), plus editor/CI/lint configs and even `.claude/settings.local.json`. A consumer who scans the downloaded tarball sees these — they're the published-surface source of CodeQL **#153/#154** (`js/exposure-of-private-files`, `testServer.js`) and **#166** (`js/incomplete-sanitization`, `rollup.config.mjs`).

## Verification (nothing runtime dropped)

`npm pack --dry-run` diff, **122 → 108 files**.

**Removed (all dev-only):**
```
.babelrc  .eslintignore  .eslintrc.json  .jshintignore  .jshintrc
.github/* (5)  .vscode/launch.json  .claude/settings.local.json
build.sh  rollup.config.mjs  tsconfig.base.json  testServer.js
```
**Added:** none.
**Preserved:** `dist/` (38), `src/` (52), `doc/` (3), `packages/` (9), `bower.json`, `logo.svg`, `CHANGELOG.md`. `main` (`dist/mixpanel.cjs.js`), `module` (`dist/mixpanel.module.js`), and `types` (`src/index.d.ts`) all confirmed present.

Build tooling stays in the repo working tree — only excluded from the tarball — so `prepublishOnly` (which runs the build at publish time) is unaffected.

## Note (out of scope here)

`packages/openfeature-web-provider/` (9 files) is a separately-published package (`@mixpanel/openfeature-web-provider`) that also ships inside this tarball. Left untouched to keep this change focused; worth a follow-up if we want it excluded too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)