### PR TITLE
fix(recorder): don't consume Request objects passed to fetch

### DIFF
--- a/src/recorder/rrweb-network-plugin.js
+++ b/src/recorder/rrweb-network-plugin.js
@@ -482,6 +482,25 @@ function initXhrObserver(cb, win, options) {
 }
 
 /**
+ * Build the Request used to inspect an outgoing fetch call.
+ *
+ * Constructing a Request from another Request marks the source's body as used, which makes
+ * the caller's own fetch fail with "Cannot construct a Request with a Request object that has
+ * already been used". Clone Request inputs first so the object the caller passed stays intact.
+ *
+ * @param {RequestInfo | URL} input
+ * @param {RequestInit} [init]
+ * @returns {Request}
+ */
+export function buildRecordedRequest(input, init) {
+    if (typeof Request !== 'undefined' && input instanceof Request) {
+        var cloned = input.clone();
+        return init ? new Request(cloned, init) : cloned;
+    }
+    return new Request(input, init);
+}
+
+/**
  * @param {networkCallback} cb
  * @param {Window} win
  * @param {Required<NetworkRecordOptions>} options
@@ -496,7 +515,7 @@ export function initFetchObserver(cb, win, options) {
 
     var restorePatch = patch(win, 'fetch', function(/** @type {typeof fetch} */ originalFetch) {
         return function() {
-            var req = new Request(arguments[0], arguments[1]);
+            var req = buildRecordedRequest(arguments[0], arguments[1]);
             /** @type {Response | undefined} */
             var res;
             /** @type {Partial<NetworkRequest>} */

--- a/tests/unit/rrweb-network-plugin.js
+++ b/tests/unit/rrweb-network-plugin.js
@@ -210,5 +210,120 @@ describe(`rrweb-network-plugin utils`, function() {
 
       win.fetch(url);
     });
+
+    it(`does not consume a Request object passed to fetch (SDK-157)`, function(done) {
+      const url = `https://example.com/api/data`;
+      const requestText = `{"hello":"world"}`;
+
+      const fakeEntry = {
+        name: url,
+        initiatorType: `fetch`,
+        entryType: `resource`,
+        startTime: 0,
+        responseEnd: 50,
+      };
+
+      let dispatchError = null;
+      const win = {
+        fetch: function(input) {
+          try {
+            // browsers construct an internal request from the input; this throws if the
+            // body has already been consumed
+            new Request(input);
+          } catch (e) {
+            dispatchError = e;
+            return Promise.reject(e);
+          }
+          return Promise.resolve(new Response(`{}`, {status: 200}));
+        },
+        performance: {
+          now: function() { return 0; },
+          getEntriesByName: function() { return [fakeEntry]; },
+        },
+      };
+
+      const options = {
+        initiatorTypes: [`fetch`],
+        recordHeaders: { request: [], response: [] },
+        recordBodyUrls: { request: [/example\.com/], response: [] },
+        ignoreRequestUrls: [],
+        ignoreRequestFn: function() { return false; },
+      };
+
+      initFetchObserver(function(data) {
+        try {
+          expect(dispatchError).to.be.null;
+          expect(data.requests[0].requestBody).to.equal(requestText);
+          expect(data.requests[0].method).to.equal(`POST`);
+          done();
+        } catch (e) {
+          done(e);
+        }
+      }, win, options);
+
+      const request = new Request(url, {
+        method: `POST`,
+        headers: {'content-type': `application/json`},
+        body: requestText,
+      });
+
+      win.fetch(request).catch((e) => done(e));
+    });
+
+    it(`does not consume a Request object passed to fetch with an init object (SDK-157)`, function(done) {
+      const url = `https://example.com/api/data`;
+      const requestText = `{"hello":"world"}`;
+
+      const fakeEntry = {
+        name: url,
+        initiatorType: `fetch`,
+        entryType: `resource`,
+        startTime: 0,
+        responseEnd: 50,
+      };
+
+      let dispatchError = null;
+      const win = {
+        fetch: function(input) {
+          try {
+            new Request(input);
+          } catch (e) {
+            dispatchError = e;
+            return Promise.reject(e);
+          }
+          return Promise.resolve(new Response(`{}`, {status: 200}));
+        },
+        performance: {
+          now: function() { return 0; },
+          getEntriesByName: function() { return [fakeEntry]; },
+        },
+      };
+
+      const options = {
+        initiatorTypes: [`fetch`],
+        recordHeaders: { request: [], response: [] },
+        recordBodyUrls: { request: [/example\.com/], response: [] },
+        ignoreRequestUrls: [],
+        ignoreRequestFn: function() { return false; },
+      };
+
+      initFetchObserver(function(data) {
+        try {
+          expect(dispatchError).to.be.null;
+          expect(data.requests[0].requestBody).to.equal(requestText);
+          expect(data.requests[0].method).to.equal(`PUT`);
+          done();
+        } catch (e) {
+          done(e);
+        }
+      }, win, options);
+
+      const request = new Request(url, {
+        method: `POST`,
+        body: requestText,
+      });
+
+      win.fetch(request, {method: `PUT`}).catch((e) => done(e));
+    });
   });
 });


### PR DESCRIPTION
## Problem

With `record_network` enabled, this breaks the customer's own fetch calls:

```js
await fetch(new Request('https://example.com/api', {
  method: 'POST',
  headers: {'content-type': 'application/json'},
  body: JSON.stringify({hello: 'world'}),
}));
// TypeError: Cannot construct a Request with a Request object that has already been used.
```

The request is never dispatched.

## Cause

`initFetchObserver` built its inspection Request with `new Request(arguments[0], arguments[1])`. Per spec, constructing a Request from another Request transfers the source's body and marks it as used. The original arguments are then passed through to the real `fetch`, which rejects the already-used Request.

Affects v2.81.0 through v2.82.1.

## Fix

Clone Request inputs before wrapping them, so the object the caller passed stays intact. Non-Request inputs (string/URL) are unchanged.

## Tests

Two regression tests in `tests/unit/rrweb-network-plugin.js` covering `fetch(request)` and `fetch(request, init)`. The fake `win.fetch` does `new Request(input)` to mimic browser dispatch. Both reproduce the exact error before the fix and pass after; they also assert `requestBody` and `method` are still recorded.

SDK-157